### PR TITLE
[#60] Implemented POST /recaps endpoint to create different types of recaps 

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -13,6 +13,7 @@ import logger from "morgan";
 // Routes
 import CuldevationsRoutes from "./culdevations/culdevations.routes";
 import AuthRoutes from "./auth/auth.routes";
+import RecapsRoutes from "./recaps/recaps.routes";
 
 class App {
   public app: Application;
@@ -45,8 +46,12 @@ class App {
     this.app.use(CuldevationsRoutes.path, CuldevationsRoutes.initializeRoutes());
 
     // Routes: /auth/**/*
-    // Purpose: for User Authentication
+    // Purpose: for User Authentication i.e. signup, login
     this.app.use(AuthRoutes.path, AuthRoutes.initializeRoutes());
+
+    // Routes: /recaps/**/*
+    // Purpose: for Recaps CRUD
+    this.app.use(RecapsRoutes.path, RecapsRoutes.initializeRoutes());
   }
 }
 

--- a/packages/backend/src/culdevations/culdevations.model.test.ts
+++ b/packages/backend/src/culdevations/culdevations.model.test.ts
@@ -1,7 +1,7 @@
 import CuldevationModel from "./culdevations.model";
 
 describe("Culdevations Model", () => {
-  test("should validate without error given all required properties", done => {
+  test("should validate without error given all required properties", () => {
     const validCuldevationModel = new CuldevationModel({
       culdevator: "Culdevator",
       title: "Culdevation title",
@@ -9,22 +9,20 @@ describe("Culdevations Model", () => {
       score: 100,
     });
 
-    validCuldevationModel.validate(err => {
-      expect(err).toBeNull();
-      done();
-    });
+    const validationErrors = validCuldevationModel.validateSync();
+
+    expect(validationErrors).toBeFalsy();
   });
 
-  test("should have validation error without required score property", done => {
+  test("should have validation error without required score property", () => {
     const invalidCuldevationModel = new CuldevationModel({
       culdevator: "Culdevator",
       title: "Culdevation title",
       description: "Culdevation description",
     });
 
-    invalidCuldevationModel.validate(err => {
-      expect(err.errors.score).toBeTruthy();
-      done();
-    });
+    const validationErrors = invalidCuldevationModel.validateSync();
+
+    expect(validationErrors.errors.score).toBeTruthy();
   });
 });

--- a/packages/backend/src/interfaces/requestWithUser.ts
+++ b/packages/backend/src/interfaces/requestWithUser.ts
@@ -1,6 +1,12 @@
 import { Request } from "express";
 import { User } from "../users/users.model";
 
+export interface UserData {
+  username: User["username"];
+  email: User["email"];
+  id: string;
+}
+
 export interface RequestWithUser extends Request {
-  user: User;
+  user: UserData;
 }

--- a/packages/backend/src/middleware/auth.middleware.test.ts
+++ b/packages/backend/src/middleware/auth.middleware.test.ts
@@ -92,8 +92,9 @@ describe("Auth Middleware", () => {
     const next = mockNext();
 
     // Mock out decoded token from Authorization header
+    const userId = "user_id";
     const jwtSpy = (jest.spyOn(jwt, "verify") as jest.SpyInstance).mockImplementation(
-      () => ({ username: "user", id: "user_id" } as AuthTokenPayload),
+      () => ({ username: "user", id: userId } as AuthTokenPayload),
     );
 
     // Mock out matching user
@@ -108,7 +109,11 @@ describe("Auth Middleware", () => {
 
     await authMiddleware(req, res, next);
 
-    expect(req.user).toMatchObject(user);
+    expect(req.user).toMatchObject({
+      username: user.username,
+      email: user.email,
+      id: userId,
+    });
     expect(next).toHaveBeenCalled();
 
     jwtSpy.mockRestore();

--- a/packages/backend/src/middleware/auth.middleware.ts
+++ b/packages/backend/src/middleware/auth.middleware.ts
@@ -37,7 +37,11 @@ const authMiddleware = async (req: RequestWithUser, res: Response, next: NextFun
     }
 
     // Pass logged in user data to authenticated routes for them to use
-    req.user = user;
+    req.user = {
+      username: user.username,
+      email: user.email,
+      id,
+    };
     next();
   } catch (error) {
     res.status(401).json({

--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -1,5 +1,74 @@
-describe("Recap Controller", () => {
-  test("should be true", () => {
-    expect(true).toBe(true);
+import RecapsController from "./recaps.controller";
+import RecapsDao from "./recaps.dao";
+import { Recap } from "./recaps.model";
+import { mockRequestWithUser } from "../testUtils/mockRequestWithUser";
+import { mockResponse } from "../testUtils/mockResponse";
+import { generateObjectIdString } from "../testUtils/generateObjectId";
+
+describe("Recaps Controller", () => {
+  const userId = generateObjectIdString();
+
+  describe("When creating a recap", () => {
+    test("should return 201 status with created recap data on success", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const createRecapSpy = (jest.spyOn(RecapsDao, "createRecap") as jest.SpyInstance).mockImplementation(() =>
+        Promise.resolve(recap),
+      );
+
+      await RecapsController.createRecap(req, res);
+
+      expect(createRecapSpy).toHaveBeenCalledWith(recap);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(recap);
+
+      createRecapSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on server error", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const createRecapSpy = (jest.spyOn(RecapsDao, "createRecap") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error"),
+      );
+
+      await RecapsController.createRecap(req, res);
+
+      expect(createRecapSpy).toHaveBeenCalledWith(recap);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to create recap." });
+
+      createRecapSpy.mockRestore();
+    });
   });
 });

--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -1,0 +1,5 @@
+describe("Recap Controller", () => {
+  test("should be true", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -1,0 +1,24 @@
+import { Response } from "express";
+import { RequestWithUser } from "../interfaces/requestWithUser";
+import RecapsDao from "./recaps.dao";
+import { Recap } from "./recaps.model";
+
+const RecapsController = {
+  async createRecap(req: RequestWithUser, res: Response) {
+    const currentUser = req.user;
+    const recap: Recap = {
+      ...req.body,
+      userId: currentUser.id,
+    };
+
+    try {
+      const createdRecap = await RecapsDao.createRecap(recap);
+
+      res.status(201).json(createdRecap);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to create recap." });
+    }
+  },
+};
+
+export default RecapsController;

--- a/packages/backend/src/recaps/recaps.dao.test.ts
+++ b/packages/backend/src/recaps/recaps.dao.test.ts
@@ -1,36 +1,30 @@
 import RecapsDao from "./recaps.dao";
 import {
-  RecapBaseModel,
-  RecapKind,
-  RecapBase,
   RecapWorkExperienceModel,
   RecapWorkExperience,
-  RecapEducationModel,
   RecapEducation,
-  RecapAccomplishmentsModel,
   RecapAccomplishments,
-  RecapPublicationsModel,
   RecapPublications,
   RecapSkillsModel,
   RecapSkills,
-  RecapSideProjectsModel,
   RecapSideProjects,
-  RecapOrganizationsModel,
   RecapOrganizations,
-  RecapReferencesModel,
   RecapReferences,
   RecapOtherModel,
   RecapOther,
-  Recap,
 } from "./recaps.model";
 import DbTestHelper from "../testUtils/dbTestHelper";
+import { generateObjectId } from "../testUtils/generateObjectId";
 
 const dbTestHelper = new DbTestHelper();
 
+const userId = generateObjectId();
+const userIdString = userId.toString();
 const formBaseRecap = () => ({
   startDate: new Date(),
   endDate: new Date(),
   bulletPoints: [],
+  userId,
 });
 
 describe("Recaps Dao", () => {
@@ -59,7 +53,7 @@ describe("Recaps Dao", () => {
 
     await Promise.all([workExperienceRecapModel.save(), skillsRecapModel.save()]);
 
-    const actualFoundRecaps = await RecapsDao.findAllRecaps();
+    const actualFoundRecaps = await RecapsDao.findAllRecaps(userIdString);
     const expectedFoundRecaps = [workExperienceRecap, skillsRecap];
 
     // Workaround to compare these objects: https://github.com/facebook/jest/issues/8475
@@ -228,7 +222,10 @@ describe("Recaps Dao", () => {
       company: "Updated Company",
       employmentType: "Part-Time",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedWorkExperienceRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedWorkExperienceRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedWorkExperienceRecap);
@@ -254,7 +251,10 @@ describe("Recaps Dao", () => {
       degree: "Updated Degree",
       grade: "Updated Grade",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedEducationRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedEducationRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedEducationRecap);
@@ -274,7 +274,10 @@ describe("Recaps Dao", () => {
       type: "Personal",
       title: "Updated Title",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedAccomplishmentsRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedAccomplishmentsRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedAccomplishmentsRecap);
@@ -300,7 +303,10 @@ describe("Recaps Dao", () => {
       url: "Updated Url",
       publisher: "Updated Publisher",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedPublicationsRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedPublicationsRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedPublicationsRecap);
@@ -320,7 +326,10 @@ describe("Recaps Dao", () => {
       title: "Updated Title",
       proficiency: "Novice",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedSkillsRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedSkillsRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedSkillsRecap);
@@ -340,7 +349,10 @@ describe("Recaps Dao", () => {
       title: "Updated Title",
       creators: "Updated Creators",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedSideProjectsRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedSideProjectsRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedSideProjectsRecap);
@@ -362,7 +374,10 @@ describe("Recaps Dao", () => {
       positions: "Updated Positions",
       location: "Updated Location",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedOrganizationsRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedOrganizationsRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedOrganizationsRecap);
@@ -386,7 +401,10 @@ describe("Recaps Dao", () => {
       phoneNumber: "562",
       email: "updatedemail@domain.com",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedReferencesRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedReferencesRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedReferencesRecap);
@@ -404,7 +422,10 @@ describe("Recaps Dao", () => {
       ...otherRecap,
       title: "Updated Title",
     };
-    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedOtherRecap);
+    const actualUpdatedRecap = await RecapsDao.updateRecapById({
+      recapId: createdRecap._id,
+      updatedRecap: updatedOtherRecap,
+    });
     const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
 
     expect(foundUpdatedRecap.toObject()).toMatchObject(updatedOtherRecap);

--- a/packages/backend/src/recaps/recaps.dao.test.ts
+++ b/packages/backend/src/recaps/recaps.dao.test.ts
@@ -1,0 +1,434 @@
+import RecapsDao from "./recaps.dao";
+import {
+  RecapBaseModel,
+  RecapKind,
+  RecapBase,
+  RecapWorkExperienceModel,
+  RecapWorkExperience,
+  RecapEducationModel,
+  RecapEducation,
+  RecapAccomplishmentsModel,
+  RecapAccomplishments,
+  RecapPublicationsModel,
+  RecapPublications,
+  RecapSkillsModel,
+  RecapSkills,
+  RecapSideProjectsModel,
+  RecapSideProjects,
+  RecapOrganizationsModel,
+  RecapOrganizations,
+  RecapReferencesModel,
+  RecapReferences,
+  RecapOtherModel,
+  RecapOther,
+  Recap,
+} from "./recaps.model";
+import DbTestHelper from "../testUtils/dbTestHelper";
+
+const dbTestHelper = new DbTestHelper();
+
+const formBaseRecap = () => ({
+  startDate: new Date(),
+  endDate: new Date(),
+  bulletPoints: [],
+});
+
+describe("Recaps Dao", () => {
+  beforeAll(async () => {
+    await dbTestHelper.startDb();
+  });
+
+  test("should find all recaps", async () => {
+    const workExperienceRecap: RecapWorkExperience = {
+      ...formBaseRecap(),
+      kind: "WorkExperience",
+      title: "Job Title",
+      location: "Job Location",
+      company: "Company",
+      employmentType: "Full-Time",
+    };
+    const workExperienceRecapModel = new RecapWorkExperienceModel(workExperienceRecap);
+
+    const skillsRecap: RecapSkills = {
+      ...formBaseRecap(),
+      kind: "Skills",
+      title: "Skill",
+      proficiency: "Advanced",
+    };
+    const skillsRecapModel = new RecapSkillsModel(skillsRecap);
+
+    await Promise.all([workExperienceRecapModel.save(), skillsRecapModel.save()]);
+
+    const actualFoundRecaps = await RecapsDao.findAllRecaps();
+    const expectedFoundRecaps = [workExperienceRecap, skillsRecap];
+
+    // Workaround to compare these objects: https://github.com/facebook/jest/issues/8475
+    expect(actualFoundRecaps.map(actualFoundRecap => actualFoundRecap.toObject())).toMatchObject(expectedFoundRecaps);
+  });
+
+  test("should find recap by id", async () => {
+    const otherRecap: RecapOther = {
+      ...formBaseRecap(),
+      kind: "Other",
+      title: "Other Title",
+    };
+    const otherRecapModel = new RecapOtherModel(otherRecap);
+
+    await otherRecapModel.save();
+
+    const actualFoundRecap = await RecapsDao.findRecapById(otherRecapModel._id);
+    const expectedFoundRecap = otherRecap;
+
+    expect(actualFoundRecap.toObject()).toMatchObject(expectedFoundRecap);
+  });
+
+  test("should be able to create a work experience recap", async () => {
+    const workExperienceRecap: RecapWorkExperience = {
+      ...formBaseRecap(),
+      kind: "WorkExperience",
+      title: "Job Title",
+      location: "Job Location",
+      company: "Company",
+      employmentType: "Full-Time",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(workExperienceRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(workExperienceRecap);
+  });
+
+  test("should be able to create an education recap", async () => {
+    const educationRecap: RecapEducation = {
+      ...formBaseRecap(),
+      kind: "Education",
+      school: "School",
+      location: "Location",
+      fieldOfStudy: "Field of Study",
+      degree: "Degree",
+      grade: "Alumnus",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(educationRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(educationRecap);
+  });
+
+  test("should be able to create an accomplishments recap", async () => {
+    const accomplishmentsRecap: RecapAccomplishments = {
+      ...formBaseRecap(),
+      kind: "Accomplishments",
+      type: "Career",
+      title: "Accomplishment Title",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(accomplishmentsRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(accomplishmentsRecap);
+  });
+
+  test("should be able to create a publications recap", async () => {
+    const publicationsRecap: RecapPublications = {
+      ...formBaseRecap(),
+      kind: "Publications",
+      title: "Title",
+      type: "Blog",
+      coauthors: "Authors",
+      url: "Url",
+      publisher: "Publisher",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(publicationsRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(publicationsRecap);
+  });
+
+  test("should be able to create a skills recap", async () => {
+    const skillsRecap: RecapSkills = {
+      ...formBaseRecap(),
+      kind: "Skills",
+      title: "Title",
+      proficiency: "Expert",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(skillsRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(skillsRecap);
+  });
+
+  test("should be able to create a side projects recap", async () => {
+    const sideProjectsRecap: RecapSideProjects = {
+      ...formBaseRecap(),
+      kind: "SideProjects",
+      title: "Title",
+      creators: "Creators",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(sideProjectsRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(sideProjectsRecap);
+  });
+
+  test("should be able to create an organizations recap", async () => {
+    const organizationsRecap: RecapOrganizations = {
+      ...formBaseRecap(),
+      kind: "Organizations",
+      organizationName: "Name",
+      positions: "Positions",
+      location: "Location",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(organizationsRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(organizationsRecap);
+  });
+
+  test("should be able to create a references recap", async () => {
+    const referencesRecap: RecapReferences = {
+      ...formBaseRecap(),
+      kind: "References",
+      company: "Company",
+      title: "Title",
+      phoneNumber: "911",
+      email: "email@domain.com",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(referencesRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(referencesRecap);
+  });
+
+  test("should be able to create an other recap", async () => {
+    const otherRecap: RecapOther = {
+      ...formBaseRecap(),
+      kind: "Other",
+      title: "Other Title",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(otherRecap);
+    const foundCreatedRecap = await RecapsDao.findRecapById(actualCreatedRecap._id);
+
+    expect(foundCreatedRecap.toObject()).toMatchObject(otherRecap);
+  });
+
+  test("should be able to update a work experience recap", async () => {
+    const workExperienceRecap: RecapWorkExperience = {
+      ...formBaseRecap(),
+      kind: "WorkExperience",
+      title: "Job Title",
+      location: "Job Location",
+      company: "Company",
+      employmentType: "Full-Time",
+    };
+    const createdRecap = await RecapsDao.createRecap(workExperienceRecap);
+
+    const updatedWorkExperienceRecap: RecapWorkExperience = {
+      ...workExperienceRecap,
+      bulletPoints: ["Bullet point"],
+      title: "Updated Job Title",
+      location: "Updated Job Location",
+      company: "Updated Company",
+      employmentType: "Part-Time",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedWorkExperienceRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedWorkExperienceRecap);
+  });
+
+  test("should be able to update an education recap", async () => {
+    const educationRecap: RecapEducation = {
+      ...formBaseRecap(),
+      kind: "Education",
+      school: "School",
+      location: "Location",
+      fieldOfStudy: "Field of Study",
+      degree: "Degree",
+      grade: "Alumnus",
+    };
+    const createdRecap = await RecapsDao.createRecap(educationRecap);
+
+    const updatedEducationRecap: RecapEducation = {
+      ...educationRecap,
+      school: "Updated School",
+      location: "Updated Location",
+      fieldOfStudy: "Updated Field of Study",
+      degree: "Updated Degree",
+      grade: "Updated Grade",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedEducationRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedEducationRecap);
+  });
+
+  test("should be able to update an accomplishments recap", async () => {
+    const accomplishmentsRecap: RecapAccomplishments = {
+      ...formBaseRecap(),
+      kind: "Accomplishments",
+      type: "Career",
+      title: "Accomplishment Title",
+    };
+    const createdRecap = await RecapsDao.createRecap(accomplishmentsRecap);
+
+    const updatedAccomplishmentsRecap: RecapAccomplishments = {
+      ...accomplishmentsRecap,
+      type: "Personal",
+      title: "Updated Title",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedAccomplishmentsRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedAccomplishmentsRecap);
+  });
+
+  test("should be able to update a publications recap", async () => {
+    const publicationsRecap: RecapPublications = {
+      ...formBaseRecap(),
+      kind: "Publications",
+      title: "Title",
+      type: "Blog",
+      coauthors: "Authors",
+      url: "Url",
+      publisher: "Publisher",
+    };
+    const createdRecap = await RecapsDao.createRecap(publicationsRecap);
+
+    const updatedPublicationsRecap: RecapPublications = {
+      ...publicationsRecap,
+      title: "Updated Title",
+      type: "Book",
+      coauthors: "Updated Authors",
+      url: "Updated Url",
+      publisher: "Updated Publisher",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedPublicationsRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedPublicationsRecap);
+  });
+
+  test("should be able to update a skills recap", async () => {
+    const skillsRecap: RecapSkills = {
+      ...formBaseRecap(),
+      kind: "Skills",
+      title: "Title",
+      proficiency: "Expert",
+    };
+    const createdRecap = await RecapsDao.createRecap(skillsRecap);
+
+    const updatedSkillsRecap: RecapSkills = {
+      ...skillsRecap,
+      title: "Updated Title",
+      proficiency: "Novice",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedSkillsRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedSkillsRecap);
+  });
+
+  test("should be able to update a side projects recap", async () => {
+    const sideProjectsRecap: RecapSideProjects = {
+      ...formBaseRecap(),
+      kind: "SideProjects",
+      title: "Title",
+      creators: "Creators",
+    };
+    const createdRecap = await RecapsDao.createRecap(sideProjectsRecap);
+
+    const updatedSideProjectsRecap: RecapSideProjects = {
+      ...sideProjectsRecap,
+      title: "Updated Title",
+      creators: "Updated Creators",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedSideProjectsRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedSideProjectsRecap);
+  });
+
+  test("should be able to update an organizations recap", async () => {
+    const organizationsRecap: RecapOrganizations = {
+      ...formBaseRecap(),
+      kind: "Organizations",
+      organizationName: "Name",
+      positions: "Positions",
+      location: "Location",
+    };
+    const createdRecap = await RecapsDao.createRecap(organizationsRecap);
+
+    const updatedOrganizationsRecap: RecapOrganizations = {
+      ...organizationsRecap,
+      organizationName: "Updated Name",
+      positions: "Updated Positions",
+      location: "Updated Location",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedOrganizationsRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedOrganizationsRecap);
+  });
+
+  test("should be able to update a references recap", async () => {
+    const referencesRecap: RecapReferences = {
+      ...formBaseRecap(),
+      kind: "References",
+      company: "Company",
+      title: "Title",
+      phoneNumber: "911",
+      email: "email@domain.com",
+    };
+    const createdRecap = await RecapsDao.createRecap(referencesRecap);
+
+    const updatedReferencesRecap: RecapReferences = {
+      ...referencesRecap,
+      company: "Updated Company",
+      title: "Updated Title",
+      phoneNumber: "562",
+      email: "updatedemail@domain.com",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedReferencesRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedReferencesRecap);
+  });
+
+  test("should be able to update an other recap", async () => {
+    const otherRecap: RecapOther = {
+      ...formBaseRecap(),
+      kind: "Other",
+      title: "Other Title",
+    };
+    const createdRecap = await RecapsDao.createRecap(otherRecap);
+
+    const updatedOtherRecap: RecapOther = {
+      ...otherRecap,
+      title: "Updated Title",
+    };
+    const actualUpdatedRecap = await RecapsDao.updateRecapById(createdRecap._id, updatedOtherRecap);
+    const foundUpdatedRecap = await RecapsDao.findRecapById(actualUpdatedRecap._id);
+
+    expect(foundUpdatedRecap.toObject()).toMatchObject(updatedOtherRecap);
+  });
+
+  test("should be able to remove recap by id", async () => {
+    const otherRecap: RecapOther = {
+      ...formBaseRecap(),
+      kind: "Other",
+      title: "Other Title",
+    };
+    const actualCreatedRecap = await RecapsDao.createRecap(otherRecap);
+
+    const actualRemovedRecap = await RecapsDao.removeRecapById(actualCreatedRecap._id);
+    const findRemovedRecapResult = await RecapsDao.findRecapById(actualRemovedRecap._id);
+
+    expect(findRemovedRecapResult).toBeNull();
+  });
+
+  afterEach(async () => {
+    await dbTestHelper.cleanUpDb();
+  });
+
+  afterAll(async () => {
+    await dbTestHelper.stopDb();
+  });
+});

--- a/packages/backend/src/recaps/recaps.dao.ts
+++ b/packages/backend/src/recaps/recaps.dao.ts
@@ -13,8 +13,8 @@ import {
 } from "./recaps.model";
 
 const RecapsDao = {
-  findAllRecaps() {
-    return RecapBaseModel.find();
+  findAllRecaps(userId: string) {
+    return RecapBaseModel.find({ userId });
   },
 
   findRecapById(recapId: string) {
@@ -55,7 +55,7 @@ const RecapsDao = {
     }
   },
 
-  updateRecapById(recapId: string, updatedRecap: Recap) {
+  updateRecapById({ recapId, updatedRecap }: { recapId: string; updatedRecap: Recap }) {
     switch (updatedRecap.kind) {
       case "WorkExperience":
         return RecapWorkExperienceModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });

--- a/packages/backend/src/recaps/recaps.dao.ts
+++ b/packages/backend/src/recaps/recaps.dao.ts
@@ -1,0 +1,88 @@
+import {
+  RecapBaseModel,
+  RecapWorkExperienceModel,
+  RecapEducationModel,
+  RecapAccomplishmentsModel,
+  RecapPublicationsModel,
+  RecapSkillsModel,
+  RecapSideProjectsModel,
+  RecapOrganizationsModel,
+  RecapReferencesModel,
+  RecapOtherModel,
+  Recap,
+} from "./recaps.model";
+
+const RecapsDao = {
+  findAllRecaps() {
+    return RecapBaseModel.find();
+  },
+
+  findRecapById(recapId: string) {
+    return RecapBaseModel.findById(recapId);
+  },
+
+  createRecap(recap: Recap) {
+    switch (recap.kind) {
+      case "WorkExperience":
+        const workExperienceRecap = new RecapWorkExperienceModel(recap);
+        return workExperienceRecap.save();
+      case "Education":
+        const educationRecap = new RecapEducationModel(recap);
+        return educationRecap.save();
+      case "Accomplishments":
+        const accomplishmentsRecap = new RecapAccomplishmentsModel(recap);
+        return accomplishmentsRecap.save();
+      case "Publications":
+        const publicationsRecap = new RecapPublicationsModel(recap);
+        return publicationsRecap.save();
+      case "Skills":
+        const skillsRecap = new RecapSkillsModel(recap);
+        return skillsRecap.save();
+      case "SideProjects":
+        const sideProjectsRecap = new RecapSideProjectsModel(recap);
+        return sideProjectsRecap.save();
+      case "Organizations":
+        const organizationsRecap = new RecapOrganizationsModel(recap);
+        return organizationsRecap.save();
+      case "References":
+        const referencesRecap = new RecapReferencesModel(recap);
+        return referencesRecap.save();
+      case "Other":
+        const otherRecap = new RecapOtherModel(recap);
+        return otherRecap.save();
+      default:
+        throw new Error("Failed to find matching recap kind to create!");
+    }
+  },
+
+  updateRecapById(recapId: string, updatedRecap: Recap) {
+    switch (updatedRecap.kind) {
+      case "WorkExperience":
+        return RecapWorkExperienceModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Education":
+        return RecapEducationModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Accomplishments":
+        return RecapAccomplishmentsModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Publications":
+        return RecapPublicationsModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Skills":
+        return RecapSkillsModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "SideProjects":
+        return RecapSideProjectsModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Organizations":
+        return RecapOrganizationsModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "References":
+        return RecapReferencesModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      case "Other":
+        return RecapOtherModel.findOneAndUpdate({ _id: recapId }, updatedRecap, { new: true });
+      default:
+        throw new Error("Failed to find matching recap kind to create!");
+    }
+  },
+
+  removeRecapById(recapId: string) {
+    return RecapBaseModel.findByIdAndDelete({ _id: recapId });
+  },
+};
+
+export default RecapsDao;

--- a/packages/backend/src/recaps/recaps.model.test.ts
+++ b/packages/backend/src/recaps/recaps.model.test.ts
@@ -5,28 +5,256 @@ import {
   RecapAccomplishmentsModel,
   RecapSkillsModel,
   RecapSideProjectsModel,
+  RecapOrganizationsModel,
   RecapReferencesModel,
   RecapOtherModel,
 } from "./recaps.model";
 import { MAX_BULLETPOINTS, MAX_BULLETPOINT_LENGTH, MAX_GENERAL_LENGTH } from "./recaps.validation";
 
 describe("Recaps Model", () => {
-  test("should be true", () => {
-    expect(true).toBe(true);
+  describe("When forming RecapWorkExperience", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapWorkExperienceModel = new RecapWorkExperienceModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Work Title",
+        location: "Work Location",
+        company: "Work Company",
+        employmentType: "Part-Time",
+      });
+
+      const validationErrors = validRecapWorkExperienceModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required title property", () => {
+      const invalidRecapWorkExperienceModel = new RecapWorkExperienceModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        location: "Work Location",
+        company: "Work Company",
+        employmentType: "Part-Time",
+      });
+
+      const validationErrors = invalidRecapWorkExperienceModel.validateSync();
+
+      expect(validationErrors.errors.title).toBeTruthy();
+    });
   });
-  // describe("When forming RecapBase", () => {});
 
-  // describe("When forming RecapWorkExperience", () => {});
+  describe("When forming RecapEducation", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapEducationModel = new RecapEducationModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        school: "School",
+        location: "Location",
+        degree: "Degree",
+        fieldOfStudy: "Field of Study",
+        grade: "Alumnus",
+      });
 
-  // describe("When forming RecapEducation", () => {});
+      const validationErrors = validRecapEducationModel.validateSync();
 
-  // describe("When forming RecapAccomplishments", () => {});
+      expect(validationErrors).toBeFalsy();
+    });
 
-  // describe("When forming RecapSkills", () => {});
+    test("should have validation error without required school property", () => {
+      const invalidRecapEducationModel = new RecapEducationModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        location: "Location",
+        degree: "Degree",
+        fieldOfStudy: "Field of Study",
+        grade: "Alumnus",
+      });
 
-  // describe("When forming RecapSideProjects", () => {});
+      const validationErrors = invalidRecapEducationModel.validateSync();
 
-  // describe("When forming RecapReferences", () => {});
+      expect(validationErrors.errors.school).toBeTruthy();
+    });
+  });
 
-  // describe("When forming RecapOther", () => {});
+  describe("When forming RecapAccomplishments", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapAccomplishmentsModel = new RecapAccomplishmentsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Accomplishments Title",
+        type: "Career",
+      });
+
+      const validationErrors = validRecapAccomplishmentsModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required title property", () => {
+      const invalidRecapAccomplishmentsModel = new RecapAccomplishmentsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        type: "School",
+      });
+
+      const validationErrors = invalidRecapAccomplishmentsModel.validateSync();
+
+      expect(validationErrors.errors.title).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapSkills", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapSkillsModel = new RecapSkillsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Skill",
+        proficiency: "Novice",
+      });
+
+      const validationErrors = validRecapSkillsModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required proficiency property", () => {
+      const invalidRecapSkillsModel = new RecapSkillsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Skill",
+      });
+
+      const validationErrors = invalidRecapSkillsModel.validateSync();
+
+      expect(validationErrors.errors.proficiency).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapSideProjects", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapSideProjectsModel = new RecapSideProjectsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Side Project",
+        creators: "Creators",
+      });
+
+      const validationErrors = validRecapSideProjectsModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required creators property", () => {
+      const invalidRecapSideProjectsModel = new RecapSideProjectsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Side Project",
+      });
+
+      const validationErrors = invalidRecapSideProjectsModel.validateSync();
+
+      expect(validationErrors.errors.creators).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapOrganizations", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapOrganizationsModel = new RecapOrganizationsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        organizationName: "Organization",
+        location: "Location",
+        positions: "Positions",
+      });
+
+      const validationErrors = validRecapOrganizationsModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required positions property", () => {
+      const invalidRecapOrganizationsModel = new RecapOrganizationsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        organizationName: "Organization",
+        location: "Location",
+      });
+
+      const validationErrors = invalidRecapOrganizationsModel.validateSync();
+
+      expect(validationErrors.errors.positions).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapReferences", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapReferencesModel = new RecapReferencesModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        company: "Company",
+        title: "Reference Title",
+        phoneNumber: "911",
+        email: "reference@email.com",
+      });
+
+      const validationErrors = validRecapReferencesModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required email property", () => {
+      const invalidRecapReferencesModel = new RecapReferencesModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        company: "Company",
+        title: "Reference Title",
+        phoneNumber: "911",
+      });
+
+      const validationErrors = invalidRecapReferencesModel.validateSync();
+
+      expect(validationErrors.errors.email).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapOther", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapOtherModel = new RecapOtherModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Other Title",
+      });
+
+      const validationErrors = validRecapOtherModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required title property", () => {
+      const invalidRecapOtherModel = new RecapOtherModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+      });
+
+      const validationErrors = invalidRecapOtherModel.validateSync();
+
+      expect(validationErrors.errors.title).toBeTruthy();
+    });
+  });
 });

--- a/packages/backend/src/recaps/recaps.model.test.ts
+++ b/packages/backend/src/recaps/recaps.model.test.ts
@@ -1,0 +1,32 @@
+import {
+  RecapBaseModel,
+  RecapWorkExperienceModel,
+  RecapEducationModel,
+  RecapAccomplishmentsModel,
+  RecapSkillsModel,
+  RecapSideProjectsModel,
+  RecapReferencesModel,
+  RecapOtherModel,
+} from "./recaps.model";
+import { MAX_BULLETPOINTS, MAX_BULLETPOINT_LENGTH, MAX_GENERAL_LENGTH } from "./recaps.validation";
+
+describe("Recaps Model", () => {
+  test("should be true", () => {
+    expect(true).toBe(true);
+  });
+  // describe("When forming RecapBase", () => {});
+
+  // describe("When forming RecapWorkExperience", () => {});
+
+  // describe("When forming RecapEducation", () => {});
+
+  // describe("When forming RecapAccomplishments", () => {});
+
+  // describe("When forming RecapSkills", () => {});
+
+  // describe("When forming RecapSideProjects", () => {});
+
+  // describe("When forming RecapReferences", () => {});
+
+  // describe("When forming RecapOther", () => {});
+});

--- a/packages/backend/src/recaps/recaps.model.test.ts
+++ b/packages/backend/src/recaps/recaps.model.test.ts
@@ -1,15 +1,14 @@
 import {
-  RecapBaseModel,
   RecapWorkExperienceModel,
   RecapEducationModel,
   RecapAccomplishmentsModel,
+  RecapPublicationsModel,
   RecapSkillsModel,
   RecapSideProjectsModel,
   RecapOrganizationsModel,
   RecapReferencesModel,
   RecapOtherModel,
 } from "./recaps.model";
-import { MAX_BULLETPOINTS, MAX_BULLETPOINT_LENGTH, MAX_GENERAL_LENGTH } from "./recaps.validation";
 
 describe("Recaps Model", () => {
   describe("When forming RecapWorkExperience", () => {
@@ -106,6 +105,41 @@ describe("Recaps Model", () => {
       const validationErrors = invalidRecapAccomplishmentsModel.validateSync();
 
       expect(validationErrors.errors.title).toBeTruthy();
+    });
+  });
+
+  describe("When forming RecapPublications", () => {
+    test("should validate without error given all required properties", () => {
+      const validRecapPublicationsModel = new RecapPublicationsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Publications Title",
+        type: "Blog",
+        coauthors: "Coauthors",
+        publisher: "Publisher",
+        url: "Url",
+      });
+
+      const validationErrors = validRecapPublicationsModel.validateSync();
+
+      expect(validationErrors).toBeFalsy();
+    });
+
+    test("should have validation error without required type property", () => {
+      const invalidRecapPublicationsModel = new RecapPublicationsModel({
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+        title: "Publications Title",
+        coauthors: "Coauthors",
+        publisher: "Publisher",
+        url: "Url",
+      });
+
+      const validationErrors = invalidRecapPublicationsModel.validateSync();
+
+      expect(validationErrors.errors.type).toBeTruthy();
     });
   });
 

--- a/packages/backend/src/recaps/recaps.model.test.ts
+++ b/packages/backend/src/recaps/recaps.model.test.ts
@@ -9,8 +9,11 @@ import {
   RecapReferencesModel,
   RecapOtherModel,
 } from "./recaps.model";
+import { generateObjectId } from "../testUtils/generateObjectId";
 
 describe("Recaps Model", () => {
+  const userId = generateObjectId();
+
   describe("When forming RecapWorkExperience", () => {
     test("should validate without error given all required properties", () => {
       const validRecapWorkExperienceModel = new RecapWorkExperienceModel({
@@ -21,6 +24,7 @@ describe("Recaps Model", () => {
         location: "Work Location",
         company: "Work Company",
         employmentType: "Part-Time",
+        userId,
       });
 
       const validationErrors = validRecapWorkExperienceModel.validateSync();
@@ -36,6 +40,7 @@ describe("Recaps Model", () => {
         location: "Work Location",
         company: "Work Company",
         employmentType: "Part-Time",
+        userId,
       });
 
       const validationErrors = invalidRecapWorkExperienceModel.validateSync();
@@ -55,6 +60,7 @@ describe("Recaps Model", () => {
         degree: "Degree",
         fieldOfStudy: "Field of Study",
         grade: "Alumnus",
+        userId,
       });
 
       const validationErrors = validRecapEducationModel.validateSync();
@@ -71,6 +77,7 @@ describe("Recaps Model", () => {
         degree: "Degree",
         fieldOfStudy: "Field of Study",
         grade: "Alumnus",
+        userId,
       });
 
       const validationErrors = invalidRecapEducationModel.validateSync();
@@ -87,6 +94,7 @@ describe("Recaps Model", () => {
         bulletPoints: [],
         title: "Accomplishments Title",
         type: "Career",
+        userId,
       });
 
       const validationErrors = validRecapAccomplishmentsModel.validateSync();
@@ -100,6 +108,7 @@ describe("Recaps Model", () => {
         endDate: new Date(),
         bulletPoints: [],
         type: "School",
+        userId,
       });
 
       const validationErrors = invalidRecapAccomplishmentsModel.validateSync();
@@ -119,6 +128,7 @@ describe("Recaps Model", () => {
         coauthors: "Coauthors",
         publisher: "Publisher",
         url: "Url",
+        userId,
       });
 
       const validationErrors = validRecapPublicationsModel.validateSync();
@@ -135,6 +145,7 @@ describe("Recaps Model", () => {
         coauthors: "Coauthors",
         publisher: "Publisher",
         url: "Url",
+        userId,
       });
 
       const validationErrors = invalidRecapPublicationsModel.validateSync();
@@ -151,6 +162,7 @@ describe("Recaps Model", () => {
         bulletPoints: [],
         title: "Skill",
         proficiency: "Novice",
+        userId,
       });
 
       const validationErrors = validRecapSkillsModel.validateSync();
@@ -164,6 +176,7 @@ describe("Recaps Model", () => {
         endDate: new Date(),
         bulletPoints: [],
         title: "Skill",
+        userId,
       });
 
       const validationErrors = invalidRecapSkillsModel.validateSync();
@@ -180,6 +193,7 @@ describe("Recaps Model", () => {
         bulletPoints: [],
         title: "Side Project",
         creators: "Creators",
+        userId,
       });
 
       const validationErrors = validRecapSideProjectsModel.validateSync();
@@ -193,6 +207,7 @@ describe("Recaps Model", () => {
         endDate: new Date(),
         bulletPoints: [],
         title: "Side Project",
+        userId,
       });
 
       const validationErrors = invalidRecapSideProjectsModel.validateSync();
@@ -210,6 +225,7 @@ describe("Recaps Model", () => {
         organizationName: "Organization",
         location: "Location",
         positions: "Positions",
+        userId,
       });
 
       const validationErrors = validRecapOrganizationsModel.validateSync();
@@ -224,6 +240,7 @@ describe("Recaps Model", () => {
         bulletPoints: [],
         organizationName: "Organization",
         location: "Location",
+        userId,
       });
 
       const validationErrors = invalidRecapOrganizationsModel.validateSync();
@@ -242,6 +259,7 @@ describe("Recaps Model", () => {
         title: "Reference Title",
         phoneNumber: "911",
         email: "reference@email.com",
+        userId,
       });
 
       const validationErrors = validRecapReferencesModel.validateSync();
@@ -257,6 +275,7 @@ describe("Recaps Model", () => {
         company: "Company",
         title: "Reference Title",
         phoneNumber: "911",
+        userId,
       });
 
       const validationErrors = invalidRecapReferencesModel.validateSync();
@@ -272,6 +291,7 @@ describe("Recaps Model", () => {
         endDate: new Date(),
         bulletPoints: [],
         title: "Other Title",
+        userId,
       });
 
       const validationErrors = validRecapOtherModel.validateSync();
@@ -284,6 +304,7 @@ describe("Recaps Model", () => {
         startDate: new Date(),
         endDate: new Date(),
         bulletPoints: [],
+        userId,
       });
 
       const validationErrors = invalidRecapOtherModel.validateSync();

--- a/packages/backend/src/recaps/recaps.model.ts
+++ b/packages/backend/src/recaps/recaps.model.ts
@@ -42,22 +42,22 @@ const recapBaseSchema = new mongoose.Schema(
   recapBaseOptions,
 );
 
-export interface RecapBaseModel extends RecapBase, mongoose.Document {}
+interface RecapBaseDocument extends RecapBase, mongoose.Document {}
 
 // Base Recap model from which other Recap models will inherit from based on the
 // the value of the "kind" discriminator
-export const RecapBaseModel = mongoose.model<RecapBaseModel>("Recap", recapBaseSchema);
+export const RecapBaseModel = mongoose.model<RecapBaseDocument>("Recap", recapBaseSchema);
 
 // Work Experience
 
-export interface RecapWorkExperience {
+interface RecapWorkExperienceKind {
   title: string;
   location: string;
   company: string;
   employmentType: EmploymentType;
 }
 
-export type EmploymentType = "Part-Time" | "Full-Time";
+type EmploymentType = "Part-Time" | "Full-Time";
 
 const recapWorkExperienceSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
@@ -66,15 +66,20 @@ const recapWorkExperienceSchema = new mongoose.Schema({
   employmentType: { type: String, required: true, enum: ["Part-Time", "Full-Time"] },
 });
 
-export interface RecapWorkExperienceModel extends RecapBaseModel, RecapWorkExperience {}
+interface RecapWorkExperienceDocument extends RecapBaseDocument, RecapWorkExperienceKind {}
 
-const RecapWorkExperience = RecapBaseModel.discriminator("WorkExperience", recapWorkExperienceSchema);
+export const RecapWorkExperienceModel = RecapBaseModel.discriminator<RecapWorkExperienceDocument>(
+  "WorkExperience",
+  recapWorkExperienceSchema,
+);
 
-export const RecapWorkExperienceModel = mongoose.model<RecapWorkExperienceModel>("WorkExperience");
+export interface RecapWorkExperience extends RecapBase, RecapWorkExperienceKind {
+  kind: "WorkExperience";
+}
 
 // Education
 
-export interface RecapEducation {
+interface RecapEducationKind {
   school: string;
   location: string;
   degree: string;
@@ -90,20 +95,25 @@ const recapEducationSchema = new mongoose.Schema({
   grade: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
-export interface RecapEducationModel extends RecapBaseModel, RecapEducation {}
+interface RecapEducationDocument extends RecapBaseDocument, RecapEducationKind {}
 
-const RecapEducation = RecapBaseModel.discriminator("Education", recapEducationSchema);
+export const RecapEducationModel = RecapBaseModel.discriminator<RecapEducationDocument>(
+  "Education",
+  recapEducationSchema,
+);
 
-export const RecapEducationModel = mongoose.model<RecapEducationModel>("Education");
+export interface RecapEducation extends RecapBase, RecapEducationKind {
+  kind: "Education";
+}
 
 // Accomplishments
 
-export interface RecapAccomplishments {
+interface RecapAccomplishmentsKind {
   title: string;
   type: AccomplishmentsType;
 }
 
-export type AccomplishmentsType =
+type AccomplishmentsType =
   | "Personal" // Mentorship, Health, Fitness, Learning, etc.
   | "Service" // Volunteer, Community Service, Philanthropy, etc.
   | "Featured" // Presentations, Conferences, TV Shows, Public Interviews, Podcasts, Radio, etc.
@@ -123,15 +133,20 @@ const recapAccomplishmentsSchema = new mongoose.Schema({
   },
 });
 
-export interface RecapAccomplishmentsModel extends RecapBaseModel, RecapAccomplishments {}
+interface RecapAccomplishmentsDocument extends RecapBaseDocument, RecapAccomplishmentsKind {
+  kind: "Accomplishments";
+}
 
-const RecapAccomplishments = RecapBaseModel.discriminator("Accomplishments", recapAccomplishmentsSchema);
+export const RecapAccomplishmentsModel = RecapBaseModel.discriminator<RecapAccomplishmentsDocument>(
+  "Accomplishments",
+  recapAccomplishmentsSchema,
+);
 
-export const RecapAccomplishmentsModel = mongoose.model<RecapAccomplishmentsModel>("Accomplishments");
+export interface RecapAccomplishments extends RecapBase, RecapAccomplishmentsKind {}
 
 // Publications
 
-export interface RecapPublications {
+interface RecapPublicationsKind {
   title: string;
   type: PublicationType;
   coauthors: string;
@@ -139,7 +154,7 @@ export interface RecapPublications {
   url: string;
 }
 
-export type PublicationType = "Book" | "Journal" | "Newspaper" | "Magazine" | "Blog";
+type PublicationType = "Book" | "Journal" | "Newspaper" | "Magazine" | "Blog";
 
 const recapPublicationsSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
@@ -149,35 +164,42 @@ const recapPublicationsSchema = new mongoose.Schema({
   url: { type: String, required: true, maxlength: MAX_URL_LENGTH },
 });
 
-export interface RecapPublicationsModel extends RecapBaseModel, RecapPublications {}
+interface RecapPublicationsDocument extends RecapBaseDocument, RecapPublicationsKind {}
 
-const RecapPublications = RecapBaseModel.discriminator("Publications", recapPublicationsSchema);
+export const RecapPublicationsModel = RecapBaseModel.discriminator<RecapPublicationsDocument>(
+  "Publications",
+  recapPublicationsSchema,
+);
 
-export const RecapPublicationsModel = mongoose.model<RecapPublicationsModel>("Publications");
+export interface RecapPublications extends RecapBase, RecapPublicationsKind {
+  kind: "Publications";
+}
 
 // Skills
 
-export interface RecapSkills {
+interface RecapSkillsKind {
   title: string;
   proficiency: SkillsProficiency;
 }
 
-export type SkillsProficiency = "Novice" | "Intermediate" | "Advanced" | "Expert";
+type SkillsProficiency = "Novice" | "Intermediate" | "Advanced" | "Expert";
 
 const recapSkillsSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   proficiency: { type: String, required: true, enum: ["Novice", "Intermediate", "Advanced", "Expert"] },
 });
 
-export interface RecapSkillsModel extends RecapBaseModel, RecapSkills {}
+interface RecapSkillsDocument extends RecapBaseDocument, RecapSkillsKind {}
 
-const RecapSkills = RecapBaseModel.discriminator("Skills", recapSkillsSchema);
+export const RecapSkillsModel = RecapBaseModel.discriminator<RecapSkillsDocument>("Skills", recapSkillsSchema);
 
-export const RecapSkillsModel = mongoose.model<RecapSkillsModel>("Skills");
+export interface RecapSkills extends RecapBase, RecapSkillsKind {
+  kind: "Skills";
+}
 
 // Side Projects
 
-export interface RecapSideProjects {
+interface RecapSideProjectsKind {
   title: string;
   creators: string;
 }
@@ -187,15 +209,20 @@ const recapSideProjectsSchema = new mongoose.Schema({
   creators: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
-export interface RecapSideProjectsModel extends RecapBaseModel, RecapSideProjects {}
+interface RecapSideProjectsDocument extends RecapBaseDocument, RecapSideProjectsKind {}
 
-const RecapSideProjects = RecapBaseModel.discriminator("SideProjects", recapSideProjectsSchema);
+export const RecapSideProjectsModel = RecapBaseModel.discriminator<RecapSideProjectsDocument>(
+  "SideProjects",
+  recapSideProjectsSchema,
+);
 
-export const RecapSideProjectsModel = mongoose.model<RecapSideProjectsModel>("SideProjects");
+export interface RecapSideProjects extends RecapBase, RecapSideProjectsKind {
+  kind: "SideProjects";
+}
 
 // Organizations
 
-export interface RecapOrganizations {
+interface RecapOrganizationsKind {
   organizationName: string;
   location: string;
   positions: string;
@@ -207,37 +234,47 @@ const recapOrganizationsSchema = new mongoose.Schema({
   positions: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
-export interface RecapOrganizationsModel extends RecapBaseModel, RecapOrganizations {}
+interface RecapOrganizationsDocument extends RecapBaseDocument, RecapOrganizationsKind {}
 
-const RecapOrganizations = RecapBaseModel.discriminator("Organizations", recapOrganizationsSchema);
+export const RecapOrganizationsModel = RecapBaseModel.discriminator<RecapOrganizationsDocument>(
+  "Organizations",
+  recapOrganizationsSchema,
+);
 
-export const RecapOrganizationsModel = mongoose.model<RecapOrganizationsModel>("Organizations");
+export interface RecapOrganizations extends RecapBase, RecapOrganizationsKind {
+  kind: "Organizations";
+}
 
 // References
 
-export interface RecapReferences {
+interface RecapReferencesKind {
   company: string;
   title: string;
   phoneNumber: string;
   email: string;
 }
 
-export const recapReferencesSchema = new mongoose.Schema({
+const recapReferencesSchema = new mongoose.Schema({
   company: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   phoneNumber: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   email: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
-export interface RecapReferencesModel extends RecapBaseModel, RecapReferences {}
+interface RecapReferencesDocument extends RecapBaseDocument, RecapReferencesKind {}
 
-const RecapReferences = RecapBaseModel.discriminator("References", recapReferencesSchema);
+export const RecapReferencesModel = RecapBaseModel.discriminator<RecapReferencesDocument>(
+  "References",
+  recapReferencesSchema,
+);
 
-export const RecapReferencesModel = mongoose.model<RecapReferencesModel>("References");
+export interface RecapReferences extends RecapBase, RecapReferencesKind {
+  kind: "References";
+}
 
 // Other
 
-export interface RecapOther {
+interface RecapOtherKind {
   title: string;
 }
 
@@ -245,8 +282,21 @@ const recapOtherSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
-export interface RecapOtherModel extends RecapBaseModel, RecapOther {}
+interface RecapOtherDocument extends RecapBaseDocument, RecapOtherKind {}
 
-const RecapOther = RecapBaseModel.discriminator("Other", recapOtherSchema);
+export const RecapOtherModel = RecapBaseModel.discriminator<RecapOtherDocument>("Other", recapOtherSchema);
 
-export const RecapOtherModel = mongoose.model<RecapOtherModel>("Other");
+export interface RecapOther extends RecapBase, RecapOtherKind {
+  kind: "Other";
+}
+
+export type Recap =
+  | RecapWorkExperience
+  | RecapEducation
+  | RecapAccomplishments
+  | RecapPublications
+  | RecapSkills
+  | RecapSideProjects
+  | RecapOrganizations
+  | RecapReferences
+  | RecapOther;

--- a/packages/backend/src/recaps/recaps.model.ts
+++ b/packages/backend/src/recaps/recaps.model.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { UserDocument } from "../users/users.model";
 import { MAX_BULLETPOINT_LENGTH, MAX_BULLETPOINTS, MAX_GENERAL_LENGTH, MAX_URL_LENGTH } from "./recaps.validation";
 
 export interface RecapBase {
@@ -6,6 +7,7 @@ export interface RecapBase {
   startDate?: Date;
   endDate?: Date;
   bulletPoints: string[];
+  userId: UserDocument["_id"];
 }
 
 export type RecapKind =
@@ -38,6 +40,7 @@ const recapBaseSchema = new mongoose.Schema(
       required: true,
       maxlength: MAX_BULLETPOINTS,
     },
+    userId: { type: mongoose.Schema.Types.ObjectId, required: true },
   },
   recapBaseOptions,
 );

--- a/packages/backend/src/recaps/recaps.model.ts
+++ b/packages/backend/src/recaps/recaps.model.ts
@@ -1,0 +1,212 @@
+import mongoose from "mongoose";
+import { MAX_BULLETPOINT_LENGTH, MAX_BULLETPOINTS, MAX_GENERAL_LENGTH } from "./recaps.validation";
+
+export interface RecapBase {
+  kind: RecapKind;
+  startDate?: Date;
+  endDate?: Date;
+  bulletPoints: string[];
+}
+
+export type RecapKind =
+  | "WorkExperience"
+  | "Education"
+  | "Accomplishments"
+  | "Skills"
+  | "SideProjects"
+  | "Organizations"
+  | "References"
+  | "Other";
+
+const recapBaseOptions = {
+  discriminatorKey: "kind",
+  collection: "recaps",
+};
+
+const recapBaseSchema = new mongoose.Schema(
+  {
+    startDate: { type: Date },
+    endDate: { type: Date },
+    bulletPoints: {
+      type: [
+        {
+          type: String,
+          maxlength: MAX_BULLETPOINT_LENGTH,
+        },
+      ],
+      required: true,
+      maxlength: MAX_BULLETPOINTS,
+    },
+  },
+  recapBaseOptions,
+);
+
+export interface RecapBaseModel extends RecapBase, mongoose.Document {}
+
+// Base Recap model from which other Recap models will inherit from based on the
+// the value of the "kind" discriminator
+export const RecapBaseModel = mongoose.model<RecapBaseModel>("Recap", recapBaseSchema);
+
+// Work Experience
+
+export interface RecapWorkExperience {
+  title: string;
+  location: string;
+  company: string;
+  employmentType: EmploymentType;
+}
+
+export type EmploymentType = "partTime" | "fullTime";
+
+const recapWorkExperienceSchema = new mongoose.Schema({
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  location: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  company: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  employmentType: { type: String, required: true, enum: ["partTime", "fullTime"] },
+});
+
+export interface RecapWorkExperienceModel extends RecapBaseModel, RecapWorkExperience {}
+
+const RecapWorkExperience = RecapBaseModel.discriminator("WorkExperience", recapWorkExperienceSchema);
+
+export const RecapWorkExperienceModel = mongoose.model<RecapWorkExperienceModel>("WorkExperience");
+
+// Education
+
+export interface RecapEducation {
+  school: string;
+  location: string;
+  degree: string;
+  fieldOfStudy: string;
+  grade: string;
+}
+
+const recapEducationSchema = new mongoose.Schema({
+  school: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  location: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  degree: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  fieldOfStudy: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  grade: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapEducationModel extends RecapBaseModel, RecapEducation {}
+
+const RecapEducation = RecapBaseModel.discriminator("Education", recapEducationSchema);
+
+export const RecapEducationModel = mongoose.model<RecapEducationModel>("Education");
+
+// Accomplishments
+
+export interface RecapAccomplishments {
+  title: string;
+  type: string;
+}
+
+const recapAccomplishmentsSchema = new mongoose.Schema({
+  title: {
+    type: String,
+    required: true,
+    maxlength: MAX_GENERAL_LENGTH,
+  },
+  type: {
+    type: String,
+    required: true,
+    maxlength: MAX_GENERAL_LENGTH,
+  },
+});
+
+export interface RecapAccomplishmentsModel extends RecapBaseModel, RecapAccomplishments {}
+
+const RecapAccomplishments = RecapBaseModel.discriminator("Accomplishments", recapAccomplishmentsSchema);
+
+export const RecapAccomplishmentsModel = mongoose.model<RecapAccomplishmentsModel>("Accomplishments");
+
+// Skills
+
+export interface RecapSkills {
+  title: string;
+}
+
+const recapSkillsSchema = new mongoose.Schema({
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapSkillsModel extends RecapBaseModel, RecapSkills {}
+
+const RecapSkills = RecapBaseModel.discriminator("Skills", recapSkillsSchema);
+
+export const RecapSkillsModel = mongoose.model<RecapSkillsModel>("Skills");
+
+// Side Projects
+
+export interface RecapSideProjects {
+  title: string;
+}
+
+const recapSideProjectsSchema = new mongoose.Schema({
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapSideProjectsModel extends RecapBaseModel, RecapSideProjects {}
+
+const RecapSideProjects = RecapBaseModel.discriminator("SideProjects", recapSideProjectsSchema);
+
+export const RecapSideProjectsModel = mongoose.model<RecapSideProjectsModel>("SideProjects");
+
+// Organizations
+
+export interface RecapOrganizations {
+  organizationName: string;
+  location: string;
+  positions: string;
+}
+
+const recapOrganizationsSchema = new mongoose.Schema({
+  organizationName: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  location: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  positions: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapOrganizationsModel extends RecapBaseModel, RecapOrganizations {}
+
+const RecapOrganizations = RecapBaseModel.discriminator("Organizations", recapOrganizationsSchema);
+
+export const RecapOrganizationsModel = mongoose.model<RecapOrganizationsModel>("Organizations");
+
+// References
+
+export interface RecapReferences {
+  company: string;
+  title: string;
+  phoneNumber: string;
+  email: string;
+}
+
+export const recapReferencesSchema = new mongoose.Schema({
+  company: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  phoneNumber: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  email: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapReferencesModel extends RecapBaseModel, RecapReferences {}
+
+const RecapReferences = RecapBaseModel.discriminator("References", recapReferencesSchema);
+
+export const RecapReferencesModel = mongoose.model<RecapReferencesModel>("References");
+
+// Other
+
+export interface RecapOther {
+  title: string;
+}
+
+const recapOtherSchema = new mongoose.Schema({
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+});
+
+export interface RecapOtherModel extends RecapBaseModel, RecapOther {}
+
+const RecapOther = RecapBaseModel.discriminator("Other", recapOtherSchema);
+
+export const RecapOtherModel = mongoose.model<RecapOtherModel>("Other");

--- a/packages/backend/src/recaps/recaps.model.ts
+++ b/packages/backend/src/recaps/recaps.model.ts
@@ -56,13 +56,13 @@ export interface RecapWorkExperience {
   employmentType: EmploymentType;
 }
 
-export type EmploymentType = "partTime" | "fullTime";
+export type EmploymentType = "Part-Time" | "Full-Time";
 
 const recapWorkExperienceSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   location: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
   company: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
-  employmentType: { type: String, required: true, enum: ["partTime", "fullTime"] },
+  employmentType: { type: String, required: true, enum: ["Part-Time", "Full-Time"] },
 });
 
 export interface RecapWorkExperienceModel extends RecapBaseModel, RecapWorkExperience {}
@@ -99,8 +99,15 @@ export const RecapEducationModel = mongoose.model<RecapEducationModel>("Educatio
 
 export interface RecapAccomplishments {
   title: string;
-  type: string;
+  type: AccomplishmentsType;
 }
+
+export type AccomplishmentsType =
+  | "Personal" // Mentorship, Health, Fitness, Learning, etc.
+  | "Service" // Volunteer, Community Service, Philanthropy, etc.
+  | "Featured" // Presentations, Conferences, TV Shows, Public Interviews, Podcasts, Radio, etc.
+  | "School" // Test Score, Scholarship, Honor Roll, Clubs, Organizations, etc.
+  | "Career"; // Promotion, Work Awards, etc.
 
 const recapAccomplishmentsSchema = new mongoose.Schema({
   title: {
@@ -111,7 +118,7 @@ const recapAccomplishmentsSchema = new mongoose.Schema({
   type: {
     type: String,
     required: true,
-    maxlength: MAX_GENERAL_LENGTH,
+    enum: ["Personal", "Service", "Featured", "School", "Career"],
   },
 });
 
@@ -121,14 +128,21 @@ const RecapAccomplishments = RecapBaseModel.discriminator("Accomplishments", rec
 
 export const RecapAccomplishmentsModel = mongoose.model<RecapAccomplishmentsModel>("Accomplishments");
 
+// Publications
+// type: Book, Scholarly Journal, Blog, Online Article, Newspaper, Magazine, Self-Publication, Other
+
 // Skills
 
 export interface RecapSkills {
   title: string;
+  proficiency: SkillsProficiency;
 }
+
+export type SkillsProficiency = "Novice" | "Intermediate" | "Advanced" | "Expert";
 
 const recapSkillsSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  proficiency: { type: String, required: true, enum: ["Novice", "Intermediate", "Advanced", "Expert"] },
 });
 
 export interface RecapSkillsModel extends RecapBaseModel, RecapSkills {}
@@ -141,10 +155,12 @@ export const RecapSkillsModel = mongoose.model<RecapSkillsModel>("Skills");
 
 export interface RecapSideProjects {
   title: string;
+  creators: string;
 }
 
 const recapSideProjectsSchema = new mongoose.Schema({
   title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  creators: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
 });
 
 export interface RecapSideProjectsModel extends RecapBaseModel, RecapSideProjects {}

--- a/packages/backend/src/recaps/recaps.model.ts
+++ b/packages/backend/src/recaps/recaps.model.ts
@@ -1,5 +1,5 @@
 import mongoose from "mongoose";
-import { MAX_BULLETPOINT_LENGTH, MAX_BULLETPOINTS, MAX_GENERAL_LENGTH } from "./recaps.validation";
+import { MAX_BULLETPOINT_LENGTH, MAX_BULLETPOINTS, MAX_GENERAL_LENGTH, MAX_URL_LENGTH } from "./recaps.validation";
 
 export interface RecapBase {
   kind: RecapKind;
@@ -12,6 +12,7 @@ export type RecapKind =
   | "WorkExperience"
   | "Education"
   | "Accomplishments"
+  | "Publications"
   | "Skills"
   | "SideProjects"
   | "Organizations"
@@ -129,7 +130,30 @@ const RecapAccomplishments = RecapBaseModel.discriminator("Accomplishments", rec
 export const RecapAccomplishmentsModel = mongoose.model<RecapAccomplishmentsModel>("Accomplishments");
 
 // Publications
-// type: Book, Scholarly Journal, Blog, Online Article, Newspaper, Magazine, Self-Publication, Other
+
+export interface RecapPublications {
+  title: string;
+  type: PublicationType;
+  coauthors: string;
+  publisher: string;
+  url: string;
+}
+
+export type PublicationType = "Book" | "Journal" | "Newspaper" | "Magazine" | "Blog";
+
+const recapPublicationsSchema = new mongoose.Schema({
+  title: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  type: { type: String, required: true, enum: ["Book", "Journal", "Newspaper", "Magazine", "Blog"] },
+  coauthors: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  publisher: { type: String, required: true, maxlength: MAX_GENERAL_LENGTH },
+  url: { type: String, required: true, maxlength: MAX_URL_LENGTH },
+});
+
+export interface RecapPublicationsModel extends RecapBaseModel, RecapPublications {}
+
+const RecapPublications = RecapBaseModel.discriminator("Publications", recapPublicationsSchema);
+
+export const RecapPublicationsModel = mongoose.model<RecapPublicationsModel>("Publications");
 
 // Skills
 

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -1,5 +1,88 @@
-describe("Recap Routes", () => {
-  test("should be true", () => {
-    expect(true).toBe(true);
+import request from "supertest";
+import app from "../app";
+import UsersDao from "../users/users.dao";
+import UsersModel, { User } from "../users/users.model";
+import { UserCredentials } from "../auth/auth.controller";
+import DbTestHelper from "../testUtils/dbTestHelper";
+
+const dbTestHelper = new DbTestHelper();
+process.env.JWT_SECRET = "someJwtSecret";
+
+describe("Recaps Routes", () => {
+  beforeAll(async () => {
+    await dbTestHelper.startDb();
+  });
+
+  const existingUser: User = {
+    username: "existinguser",
+    email: "existingemail@test.com",
+    password: "existingpassword123",
+  };
+  let existingUserModel;
+  let authToken;
+  beforeEach(async () => {
+    const hashedExistingUserPassword = await UsersModel.hashPassword(existingUser.password);
+    existingUserModel = await UsersDao.createUser({
+      ...existingUser,
+      password: hashedExistingUserPassword,
+    });
+
+    const userCredentials: UserCredentials = {
+      username: existingUser.username,
+      password: existingUser.password,
+    };
+    await request(app)
+      .post("/auth/login")
+      .send(userCredentials)
+      .then(response => {
+        authToken = response.body.token;
+      });
+  });
+
+  describe("POST /recaps", () => {
+    test("should fail to create a recap with validation errors", async () => {
+      const invalidOtherRecapWithoutTitle = {
+        kind: "Other",
+        startDate: new Date(),
+        endDate: new Date(),
+        bulletPoints: [],
+      };
+
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(invalidOtherRecapWithoutTitle)
+        .expect(400)
+        .then(response => {
+          expect(response.body).toMatchObject({
+            message: `"title" is required`,
+          });
+        });
+    });
+
+    test("should be able to create a new recap", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201)
+        .then(response => {
+          expect(response.body).toMatchObject(validOtherRecap);
+        });
+    });
+  });
+
+  afterEach(async () => {
+    await dbTestHelper.cleanUpDb();
+  });
+
+  afterAll(async () => {
+    await dbTestHelper.stopDb();
   });
 });

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -1,0 +1,5 @@
+describe("Recap Routes", () => {
+  test("should be true", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/backend/src/recaps/recaps.routes.ts
+++ b/packages/backend/src/recaps/recaps.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import RecapsController from "./recaps.controller";
+import authMiddleware from "../middleware/auth.middleware";
+import validationMiddleware from "../middleware/validation.middleware";
+import { RecapSchema } from "./recaps.validation";
+
+const RecapsRoutes = {
+  path: "/recaps",
+  router: Router(),
+
+  initializeRoutes() {
+    // POST /recaps
+    this.router.post("/", authMiddleware, validationMiddleware(RecapSchema, "body"), RecapsController.createRecap);
+
+    return this.router;
+  },
+};
+
+export default RecapsRoutes;

--- a/packages/backend/src/recaps/recaps.validation.test.ts
+++ b/packages/backend/src/recaps/recaps.validation.test.ts
@@ -1,0 +1,251 @@
+import { RecapSchema, MAX_BULLETPOINT_LENGTH, MAX_BULLETPOINTS } from "./recaps.validation";
+import { RecapKind } from "./recaps.model";
+
+describe("Recap Validation", () => {
+  const formBaseRecap = (kind: RecapKind | string) => ({
+    kind,
+    startDate: new Date(),
+    endDate: new Date(),
+    bulletPoints: [],
+  });
+
+  describe("When validating bulletPoints", () => {
+    test("should be invalid when bullet point length is greater than max length", () => {
+      const tooLongBulletPoint = "a".repeat(MAX_BULLETPOINT_LENGTH + 1);
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Other"),
+        bulletPoints: [tooLongBulletPoint],
+        title: "OtherTitle",
+      });
+
+      expect(error).toBeTruthy();
+    });
+
+    test("should be invalid when number of bullet points is greater than max", () => {
+      const tooManyBulletPoints = Array.from({ length: MAX_BULLETPOINTS + 1 }).map(() => "bulletpoint");
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Other"),
+        bulletPoints: tooManyBulletPoints,
+        title: "Other Title",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating kind discriminator", () => {
+    test("should be invalid when given unknown kind value", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("UnknownKind"),
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapWorkExperience", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("WorkExperience"),
+        title: "Work Title",
+        location: "Work Location",
+        company: "Work Company",
+        employmentType: "partTime",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("WorkExperience"),
+        title: "Work Title",
+        location: "Work Location",
+        company: "Work Company",
+        employmentType: "partTime",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+
+    test("should be invalid given unknown employment type", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("WorkExperience"),
+        title: "Work Title",
+        location: "Work Location",
+        company: "Work Company",
+        employmentType: "invalidEmploymentType",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapEducation", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Education"),
+        school: "School",
+        location: "Location",
+        degree: "BS",
+        fieldOfStudy: "Computer Science",
+        grade: "Alumnus",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Education"),
+        school: "School",
+        location: "Location",
+        degree: "BS",
+        fieldOfStudy: "Computer Science",
+        grade: "Alumnus",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapAccomplishments", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Accomplishments"),
+        title: "Accomplishments Title",
+        type: "Accomplishment Type",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Accomplishments"),
+        title: "Accomplishments Title",
+        type: "Accomplishment Type",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapSkills", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Skills"),
+        title: "Skills Title",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Skills"),
+        title: "Skills Title",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapSideProjects", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("SideProjects"),
+        title: "Side Project Title",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("SideProjects"),
+        title: "Side Project Title",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapOrganizations", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Organizations"),
+        organizationName: "orgName",
+        location: "orgLocation",
+        positions: "orgPositions",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Organizations"),
+        organizationName: "orgName",
+        location: "orgLocation",
+        positions: "orgPositions",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapReferences", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("References"),
+        company: "Company",
+        title: "Manager",
+        phoneNumber: "911",
+        email: "manager@company.com",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("References"),
+        company: "Company",
+        title: "Manager",
+        phoneNumber: "911",
+        email: "manager@company.com",
+        wrongProperty: "wrongProperty",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
+  describe("When validating RecapOther", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Other"),
+        title: "OtherTitle",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Other"),
+        title: "Other Title",
+        wrongProperty: "OtherTitle",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+});

--- a/packages/backend/src/recaps/recaps.validation.test.ts
+++ b/packages/backend/src/recaps/recaps.validation.test.ts
@@ -50,7 +50,7 @@ describe("Recap Validation", () => {
         title: "Work Title",
         location: "Work Location",
         company: "Work Company",
-        employmentType: "partTime",
+        employmentType: "Part-Time",
       });
 
       expect(error).toBeFalsy();
@@ -62,7 +62,7 @@ describe("Recap Validation", () => {
         title: "Work Title",
         location: "Work Location",
         company: "Work Company",
-        employmentType: "partTime",
+        employmentType: "Part-Time",
         wrongProperty: "wrongProperty",
       });
 
@@ -116,17 +116,27 @@ describe("Recap Validation", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("Accomplishments"),
         title: "Accomplishments Title",
-        type: "Accomplishment Type",
+        type: "Career",
       });
 
       expect(error).toBeFalsy();
+    });
+
+    test("should be invalid when given unknown type", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Accomplishments"),
+        title: "Accomplishments Title",
+        type: "Unknown",
+      });
+
+      expect(error).toBeTruthy();
     });
 
     test("should be invalid when given unknown property", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("Accomplishments"),
         title: "Accomplishments Title",
-        type: "Accomplishment Type",
+        type: "Personal",
         wrongProperty: "wrongProperty",
       });
 
@@ -139,15 +149,27 @@ describe("Recap Validation", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("Skills"),
         title: "Skills Title",
+        proficiency: "Novice",
       });
 
       expect(error).toBeFalsy();
+    });
+
+    test("should be invalid given unknown proficiency", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Skills"),
+        title: "Skills Title",
+        proficiency: "Unknown",
+      });
+
+      expect(error).toBeTruthy();
     });
 
     test("should be invalid when given unknown property", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("Skills"),
         title: "Skills Title",
+        proficiency: "Advanced",
         wrongProperty: "wrongProperty",
       });
 
@@ -160,6 +182,7 @@ describe("Recap Validation", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("SideProjects"),
         title: "Side Project Title",
+        creators: "Creators",
       });
 
       expect(error).toBeFalsy();
@@ -169,6 +192,7 @@ describe("Recap Validation", () => {
       const { error } = RecapSchema.validate({
         ...formBaseRecap("SideProjects"),
         title: "Side Project Title",
+        creators: "Creators",
         wrongProperty: "wrongProperty",
       });
 

--- a/packages/backend/src/recaps/recaps.validation.test.ts
+++ b/packages/backend/src/recaps/recaps.validation.test.ts
@@ -177,6 +177,46 @@ describe("Recap Validation", () => {
     });
   });
 
+  describe("When validating RecapPublications", () => {
+    test("should be valid given required properties", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Publications"),
+        title: "Publication Title",
+        type: "Book",
+        coauthors: "Coauthors",
+        publisher: "Publisher",
+        url: "url.com",
+      });
+
+      expect(error).toBeFalsy();
+    });
+
+    test("should be invalid given unknown type", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Publications"),
+        title: "Publication Title",
+        type: "Unknown",
+        coauthors: "Coauthors",
+        publisher: "Publisher",
+        url: "url.com",
+      });
+
+      expect(error).toBeTruthy();
+    });
+
+    test("should be invalid given unknown property", () => {
+      const { error } = RecapSchema.validate({
+        ...formBaseRecap("Publications"),
+        title: "Publication Title",
+        type: "Journal",
+        coauthors: "Coauthors",
+        publisher: "Publisher",
+      });
+
+      expect(error).toBeTruthy();
+    });
+  });
+
   describe("When validating RecapSideProjects", () => {
     test("should be valid given required properties", () => {
       const { error } = RecapSchema.validate({

--- a/packages/backend/src/recaps/recaps.validation.ts
+++ b/packages/backend/src/recaps/recaps.validation.ts
@@ -3,6 +3,7 @@ import Joi from "@hapi/joi";
 export const MAX_BULLETPOINT_LENGTH = 1000;
 export const MAX_BULLETPOINTS = 20;
 export const MAX_GENERAL_LENGTH = 254;
+export const MAX_URL_LENGTH = 2048;
 
 const RecapWorkExperienceSchema = Joi.object({
   title: Joi.string()
@@ -43,6 +44,24 @@ const RecapAccomplishmentsSchema = Joi.object({
     .required(),
   type: Joi.string()
     .valid("Personal", "Service", "Featured", "School", "Career")
+    .required(),
+});
+
+const RecapPublicationsSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  type: Joi.string()
+    .valid("Book", "Journal", "Newspaper", "Magazine", "Blog")
+    .required(),
+  coauthors: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  publisher: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  url: Joi.string()
+    .max(MAX_URL_LENGTH)
     .required(),
 });
 
@@ -109,6 +128,7 @@ export const RecapSchema = Joi.object({
       "WorkExperience",
       "Education",
       "Accomplishments",
+      "Publications",
       "Skills",
       "SideProjects",
       "Organizations",
@@ -125,6 +145,9 @@ export const RecapSchema = Joi.object({
   })
   .when(Joi.object({ kind: "Accomplishments" }).unknown(), {
     then: RecapAccomplishmentsSchema,
+  })
+  .when(Joi.object({ kind: "Publications" }).unknown(), {
+    then: RecapPublicationsSchema,
   })
   .when(Joi.object({ kind: "Skills" }).unknown(), {
     then: RecapSkillsSchema,

--- a/packages/backend/src/recaps/recaps.validation.ts
+++ b/packages/backend/src/recaps/recaps.validation.ts
@@ -1,0 +1,137 @@
+import Joi from "@hapi/joi";
+
+export const MAX_BULLETPOINT_LENGTH = 1000;
+export const MAX_BULLETPOINTS = 20;
+export const MAX_GENERAL_LENGTH = 254;
+
+const RecapWorkExperienceSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  location: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  company: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  employmentType: Joi.string()
+    .valid("partTime", "fullTime")
+    .required(),
+});
+
+const RecapEducationSchema = Joi.object({
+  school: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  location: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  degree: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  fieldOfStudy: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  grade: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapAccomplishmentsSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  type: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapSkillsSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapSideProjectsSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapOrganizationsSchema = Joi.object({
+  organizationName: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  location: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  positions: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapReferencesSchema = Joi.object({
+  company: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  phoneNumber: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  email: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+const RecapOtherSchema = Joi.object({
+  title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+});
+
+export const RecapSchema = Joi.object({
+  startDate: Joi.date().optional(),
+  endDate: Joi.date().optional(),
+  bulletPoints: Joi.array()
+    .items(Joi.string().max(MAX_BULLETPOINT_LENGTH))
+    .max(MAX_BULLETPOINTS)
+    .required(),
+  kind: Joi.string()
+    .valid(
+      "WorkExperience",
+      "Education",
+      "Accomplishments",
+      "Skills",
+      "SideProjects",
+      "Organizations",
+      "References",
+      "Other",
+    )
+    .required(),
+})
+  .when(Joi.object({ kind: "WorkExperience" }).unknown(), {
+    then: RecapWorkExperienceSchema,
+  })
+  .when(Joi.object({ kind: "Education" }).unknown(), {
+    then: RecapEducationSchema,
+  })
+  .when(Joi.object({ kind: "Accomplishments" }).unknown(), {
+    then: RecapAccomplishmentsSchema,
+  })
+  .when(Joi.object({ kind: "Skills" }).unknown(), {
+    then: RecapSkillsSchema,
+  })
+  .when(Joi.object({ kind: "SideProjects" }).unknown(), {
+    then: RecapSideProjectsSchema,
+  })
+  .when(Joi.object({ kind: "Organizations" }).unknown(), {
+    then: RecapOrganizationsSchema,
+  })
+  .when(Joi.object({ kind: "References" }).unknown(), {
+    then: RecapReferencesSchema,
+  })
+  .when(Joi.object({ kind: "Other" }).unknown(), {
+    then: RecapOtherSchema,
+  });

--- a/packages/backend/src/recaps/recaps.validation.ts
+++ b/packages/backend/src/recaps/recaps.validation.ts
@@ -15,7 +15,7 @@ const RecapWorkExperienceSchema = Joi.object({
     .max(MAX_GENERAL_LENGTH)
     .required(),
   employmentType: Joi.string()
-    .valid("partTime", "fullTime")
+    .valid("Part-Time", "Full-Time")
     .required(),
 });
 
@@ -42,7 +42,7 @@ const RecapAccomplishmentsSchema = Joi.object({
     .max(MAX_GENERAL_LENGTH)
     .required(),
   type: Joi.string()
-    .max(MAX_GENERAL_LENGTH)
+    .valid("Personal", "Service", "Featured", "School", "Career")
     .required(),
 });
 
@@ -50,10 +50,16 @@ const RecapSkillsSchema = Joi.object({
   title: Joi.string()
     .max(MAX_GENERAL_LENGTH)
     .required(),
+  proficiency: Joi.string()
+    .valid("Novice", "Intermediate", "Advanced", "Expert")
+    .required(),
 });
 
 const RecapSideProjectsSchema = Joi.object({
   title: Joi.string()
+    .max(MAX_GENERAL_LENGTH)
+    .required(),
+  creators: Joi.string()
     .max(MAX_GENERAL_LENGTH)
     .required(),
 });

--- a/packages/backend/src/testUtils/generateObjectId.ts
+++ b/packages/backend/src/testUtils/generateObjectId.ts
@@ -1,0 +1,4 @@
+import mongoose from "mongoose";
+
+export const generateObjectId = () => mongoose.Types.ObjectId();
+export const generateObjectIdString = () => mongoose.Types.ObjectId().toString();

--- a/packages/backend/src/testUtils/mockRequestWithUser.ts
+++ b/packages/backend/src/testUtils/mockRequestWithUser.ts
@@ -1,15 +1,14 @@
-import { RequestWithUser } from "../interfaces/requestWithUser";
-import { User } from "../users/users.model";
+import { RequestWithUser, UserData } from "../interfaces/requestWithUser";
 
 interface MockRequestWithUser {
-  user?: User;
+  user?: UserData;
   authHeader?: string | null;
   body?: any;
   params?: any;
 }
 
 export const mockRequestWithUser = ({
-  user = {} as User,
+  user = {} as UserData,
   authHeader = "Bearer token",
   body = {},
   params = {},


### PR DESCRIPTION
Resolves #60 in adding /recaps POST endpoint to create Work Experience, Education, Skills, Accomplishments, Side Projects, Organizations, References, Publications, and Other Recap types with unit/integration tests

/recaps endpoints will have validation for improper request bodies and need to be authenticated to work (passing through Authorization header with auth token after signing up/logging in)