### PR TITLE
[#58] Implemented /recaps/:recapId PATCH endpoint to update a recap

### DIFF
--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -7,6 +7,7 @@ import { generateObjectIdString } from "../testUtils/generateObjectId";
 
 describe("Recaps Controller", () => {
   const userId = generateObjectIdString();
+  const recapId = generateObjectIdString();
 
   describe("When creating a recap", () => {
     test("should return 201 status with created recap data on success", async () => {
@@ -69,6 +70,76 @@ describe("Recaps Controller", () => {
       expect(res.json).toHaveBeenCalledWith({ message: "Failed to create recap." });
 
       createRecapSpy.mockRestore();
+    });
+  });
+
+  describe("When updating a recap", () => {
+    test("should return 200 status with updated recap data on success", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const updateRecapByIdSpy = (jest.spyOn(RecapsDao, "updateRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.resolve(recap),
+      );
+
+      await RecapsController.updateRecap(req, res);
+
+      expect(updateRecapByIdSpy).toHaveBeenCalledWith({ recapId, updatedRecap: { ...recap, userId } });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(recap);
+
+      updateRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on server error", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const updateRecapByIdSpy = (jest.spyOn(RecapsDao, "updateRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error"),
+      );
+
+      await RecapsController.updateRecap(req, res);
+
+      expect(updateRecapByIdSpy).toHaveBeenCalledWith({ recapId, updatedRecap: { ...recap, userId } });
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to update recap." });
+
+      updateRecapByIdSpy.mockRestore();
     });
   });
 });

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -19,6 +19,22 @@ const RecapsController = {
       res.status(500).json({ message: "Failed to create recap." });
     }
   },
+
+  async updateRecap(req: RequestWithUser, res: Response) {
+    const currentUser = req.user;
+    const recapId = req.params.recapId;
+    const updatedRecap: Recap = {
+      ...req.body,
+      userId: currentUser.id,
+    };
+
+    try {
+      const changedRecap = await RecapsDao.updateRecapById({ recapId, updatedRecap });
+      res.status(200).json(changedRecap);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to update recap." });
+    }
+  },
 };
 
 export default RecapsController;

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -40,6 +40,19 @@ describe("Recaps Routes", () => {
   });
 
   describe("POST /recaps", () => {
+    test("should fail to create a recap without proper authorization", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      await request(app)
+        .post("/recaps")
+        .send(validOtherRecap)
+        .expect(401);
+    });
+
     test("should fail to create a recap with validation errors", async () => {
       const invalidOtherRecapWithoutTitle = {
         kind: "Other",
@@ -79,6 +92,19 @@ describe("Recaps Routes", () => {
   });
 
   describe("PATCH /recaps", () => {
+    test("should fail to update recap without proper authorization", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      await request(app)
+        .patch("/recaps/recapId")
+        .send(validOtherRecap)
+        .expect(401);
+    });
+
     test("should fail to update recap with validation errors", async () => {
       const validOtherRecap = {
         kind: "Other",

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -78,6 +78,70 @@ describe("Recaps Routes", () => {
     });
   });
 
+  describe("PATCH /recaps", () => {
+    test("should fail to update recap with validation errors", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      let otherRecapId;
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201)
+        .then(response => {
+          otherRecapId = response.body._id;
+        });
+
+      const invalidUpdatedOtherRecap = {
+        ...validOtherRecap,
+        incorrectProperty: "Blah",
+      };
+      await request(app)
+        .patch(`/recaps/${otherRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(invalidUpdatedOtherRecap)
+        .expect(400)
+        .then(response => {
+          expect(response.body).toMatchObject({ message: `"incorrectProperty" is not allowed` });
+        });
+    });
+
+    test("should be able to update a recap", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      let otherRecapId;
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201)
+        .then(response => {
+          otherRecapId = response.body._id;
+        });
+
+      const updatedOtherRecap = {
+        ...validOtherRecap,
+        title: "Updated Other Title",
+      };
+      await request(app)
+        .patch(`/recaps/${otherRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(updatedOtherRecap)
+        .expect(200)
+        .then(response => {
+          expect(response.body).toMatchObject(updatedOtherRecap);
+        });
+    });
+  });
+
   afterEach(async () => {
     await dbTestHelper.cleanUpDb();
   });

--- a/packages/backend/src/recaps/recaps.routes.ts
+++ b/packages/backend/src/recaps/recaps.routes.ts
@@ -12,6 +12,14 @@ const RecapsRoutes = {
     // POST /recaps
     this.router.post("/", authMiddleware, validationMiddleware(RecapSchema, "body"), RecapsController.createRecap);
 
+    // PATCH /recaps/:recapId
+    this.router.patch(
+      "/:recapId",
+      authMiddleware,
+      validationMiddleware(RecapSchema, "body"),
+      RecapsController.updateRecap,
+    );
+
     return this.router;
   },
 };


### PR DESCRIPTION
Resolves #58 in implementing /recaps/:recapId PATCH endpoint to update a recap with validation and auth middleware checks