### PR TITLE
[#59] Implemented /recaps/:recapId DELETE endpoint to delete a recap

### DIFF
--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -94,21 +94,26 @@ describe("Recaps Controller", () => {
         },
       });
       const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
+        () => recap,
+      );
       const updateRecapByIdSpy = (jest.spyOn(RecapsDao, "updateRecapById") as jest.SpyInstance).mockImplementation(() =>
         Promise.resolve(recap),
       );
 
       await RecapsController.updateRecap(req, res);
 
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
       expect(updateRecapByIdSpy).toHaveBeenCalledWith({ recapId, updatedRecap: { ...recap, userId } });
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(recap);
 
+      findRecapByIdSpy.mockRestore();
       updateRecapByIdSpy.mockRestore();
     });
 
-    test("should return 500 status with message on server error", async () => {
+    test("should return 404 status with message on unmatched recap id", async () => {
       const recap: Recap = {
         kind: "Skills",
         proficiency: "Advanced",
@@ -128,17 +133,124 @@ describe("Recaps Controller", () => {
         },
       });
       const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
+        () => null,
+      );
+
+      await RecapsController.updateRecap(req, res);
+
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to find matching recap to update" });
+
+      findRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 404 status with message on unmatched user id", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(() => ({
+        userId: "unmatchedUserId",
+      }));
+
+      await RecapsController.updateRecap(req, res);
+
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to find matching recap to update" });
+
+      findRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on find recap by id server error", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error"),
+      );
+
+      await RecapsController.updateRecap(req, res);
+
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to update recap" });
+
+      findRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on update recap by id server error", async () => {
+      const recap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        body: recap,
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
+        () => recap,
+      );
       const updateRecapByIdSpy = (jest.spyOn(RecapsDao, "updateRecapById") as jest.SpyInstance).mockImplementation(() =>
         Promise.reject("500 error"),
       );
 
       await RecapsController.updateRecap(req, res);
 
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
       expect(updateRecapByIdSpy).toHaveBeenCalledWith({ recapId, updatedRecap: { ...recap, userId } });
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({ message: "Failed to update recap." });
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to update recap" });
 
+      findRecapByIdSpy.mockRestore();
       updateRecapByIdSpy.mockRestore();
     });
   });
@@ -162,21 +274,26 @@ describe("Recaps Controller", () => {
         },
       });
       const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
+        () => recap,
+      );
       const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(
         () => recap,
       );
 
       await RecapsController.deleteRecap(req, res);
 
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
       expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
 
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(recap);
 
       deleteRecapByIdSpy.mockRestore();
+      findRecapByIdSpy.mockRestore();
     });
 
-    test("should return 404 status with message for unmatched id", async () => {
+    test("should return 404 status with message for unmatched recap id", async () => {
       const req = mockRequestWithUser({
         params: {
           recapId,
@@ -188,23 +305,23 @@ describe("Recaps Controller", () => {
         },
       });
       const res = mockResponse();
-      const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
         () => null,
       );
 
       await RecapsController.deleteRecap(req, res);
 
-      expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(res.json).toHaveBeenCalledWith({
         message: "Failed to find matching recap to delete",
       });
 
-      deleteRecapByIdSpy.mockRestore();
+      findRecapByIdSpy.mockRestore();
     });
 
-    test("should return 500 status with message on server error", async () => {
+    test("should return 404 status with message for unmatched user id", async () => {
       const req = mockRequestWithUser({
         params: {
           recapId,
@@ -216,20 +333,87 @@ describe("Recaps Controller", () => {
         },
       });
       const res = mockResponse();
-      const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(() =>
-        Promise.reject("500 error"),
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(() => ({
+        userId: "unmatchedUserIdHash",
+      }));
+
+      await RecapsController.deleteRecap(req, res);
+
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Failed to find matching recap to delete",
+      });
+
+      findRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on find recap by id server error", async () => {
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error find recap by id"),
       );
 
       await RecapsController.deleteRecap(req, res);
 
-      expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
 
       expect(res.status).toHaveBeenCalledWith(500);
       expect(res.json).toHaveBeenCalledWith({
         message: "Failed to delete recap",
       });
 
-      deleteRecapByIdSpy.mockRestore();
+      findRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on remove recap by id server error", async () => {
+      const recap: Recap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdSpy = (jest.spyOn(RecapsDao, "findRecapById") as jest.SpyInstance).mockImplementation(
+        () => recap,
+      );
+      const removeRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error remove recap by id"),
+      );
+
+      await RecapsController.deleteRecap(req, res);
+
+      expect(findRecapByIdSpy).toHaveBeenCalledWith(recapId);
+      expect(removeRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Failed to delete recap",
+      });
+
+      findRecapByIdSpy.mockRestore();
+      removeRecapByIdSpy.mockRestore();
     });
   });
 });

--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -142,4 +142,94 @@ describe("Recaps Controller", () => {
       updateRecapByIdSpy.mockRestore();
     });
   });
+
+  describe("When deleting a recap", () => {
+    test("should return 200 status with deleted recap on success", async () => {
+      const recap: Recap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(
+        () => recap,
+      );
+
+      await RecapsController.deleteRecap(req, res);
+
+      expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(recap);
+
+      deleteRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 404 status with message for unmatched id", async () => {
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(
+        () => null,
+      );
+
+      await RecapsController.deleteRecap(req, res);
+
+      expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Failed to find matching recap to delete",
+      });
+
+      deleteRecapByIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on server error", async () => {
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const deleteRecapByIdSpy = (jest.spyOn(RecapsDao, "removeRecapById") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error"),
+      );
+
+      await RecapsController.deleteRecap(req, res);
+
+      expect(deleteRecapByIdSpy).toHaveBeenCalledWith(recapId);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Failed to delete recap",
+      });
+
+      deleteRecapByIdSpy.mockRestore();
+    });
+  });
 });

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -29,22 +29,46 @@ const RecapsController = {
     };
 
     try {
+      const foundRecap = await RecapsDao.findRecapById(recapId);
+      const isMatchingUserId = foundRecap && foundRecap.userId.toString() === currentUser.id;
+
+      if (!foundRecap || !isMatchingUserId) {
+        return res.status(404).json({ message: "Failed to find matching recap to update" });
+      }
+
       const changedRecap = await RecapsDao.updateRecapById({ recapId, updatedRecap });
-      res.status(200).json(changedRecap);
+
+      if (changedRecap) {
+        res.status(200).json(changedRecap);
+      } else {
+        // If by some chance it got deleted while we were trying to update it
+        // we'll still get a 404 back
+        res.status(404).json({ message: "Failed to find matching recap to update" });
+      }
     } catch (err) {
-      res.status(500).json({ message: "Failed to update recap." });
+      res.status(500).json({ message: "Failed to update recap" });
     }
   },
 
   async deleteRecap(req: RequestWithUser, res: Response) {
     const recapId = req.params.recapId;
+    const currentUser = req.user;
 
     try {
+      const foundRecap = await RecapsDao.findRecapById(recapId);
+      const isMatchingUserId = foundRecap && foundRecap.userId.toString() === currentUser.id;
+
+      if (!foundRecap || !isMatchingUserId) {
+        return res.status(404).json({ message: "Failed to find matching recap to delete" });
+      }
+
       const deletedRecap = await RecapsDao.removeRecapById(recapId);
 
       if (deletedRecap) {
         res.status(200).json(deletedRecap);
       } else {
+        // If by some chance it got deleted while we were trying to delete it
+        // we'll still get a 404 back
         res.status(404).json({ message: "Failed to find matching recap to delete" });
       }
     } catch (err) {

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -35,6 +35,22 @@ const RecapsController = {
       res.status(500).json({ message: "Failed to update recap." });
     }
   },
+
+  async deleteRecap(req: RequestWithUser, res: Response) {
+    const recapId = req.params.recapId;
+
+    try {
+      const deletedRecap = await RecapsDao.removeRecapById(recapId);
+
+      if (deletedRecap) {
+        res.status(200).json(deletedRecap);
+      } else {
+        res.status(404).json({ message: "Failed to find matching recap to delete" });
+      }
+    } catch (err) {
+      res.status(500).json({ message: "Failed to delete recap" });
+    }
+  },
 };
 
 export default RecapsController;

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
 import app from "../app";
+import { Recap } from "../recaps/recaps.model";
+import RecapsDao from "../recaps/recaps.dao";
 import UsersDao from "../users/users.dao";
 import UsersModel, { User } from "../users/users.model";
 import { UserCredentials } from "../auth/auth.controller";
@@ -21,6 +23,14 @@ describe("Recaps Routes", () => {
   };
   let existingUserModel;
   let authToken;
+  const otherUserId = generateObjectIdString();
+  const otherUserRecap: Recap = {
+    kind: "Other",
+    bulletPoints: [],
+    title: "Other User",
+    userId: otherUserId,
+  };
+  let otherUserRecapId;
   beforeEach(async () => {
     const hashedExistingUserPassword = await UsersModel.hashPassword(existingUser.password);
     existingUserModel = await UsersDao.createUser({
@@ -38,6 +48,9 @@ describe("Recaps Routes", () => {
       .then(response => {
         authToken = response.body.token;
       });
+
+    const createdOtherUserRecap = await RecapsDao.createRecap(otherUserRecap);
+    otherUserRecapId = createdOtherUserRecap._id;
   });
 
   describe("POST /recaps", () => {
@@ -137,6 +150,22 @@ describe("Recaps Routes", () => {
         });
     });
 
+    test("should fail to update another user's recap", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+      await request(app)
+        .patch(`/recaps/${otherUserRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(404)
+        .then(response => {
+          expect(response.body).toMatchObject({ message: "Failed to find matching recap to update" });
+        });
+    });
+
     test("should be able to update a recap", async () => {
       const validOtherRecap = {
         kind: "Other",
@@ -187,6 +216,14 @@ describe("Recaps Routes", () => {
             message: "Failed to find matching recap to delete",
           });
         });
+    });
+
+    test("should fail to delete another user's recap", async () => {
+      await request(app)
+        .delete(`/recaps/${otherUserRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(404)
+        .then(response => expect(response.body).toMatchObject({ message: "Failed to find matching recap to delete" }));
     });
 
     test("should successfully delete an existing recap", async () => {

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -176,7 +176,7 @@ describe("Recaps Routes", () => {
         .expect(401);
     });
 
-    test("should return 404 after trying to delete non-existent recap", async () => {
+    test("should fail to delete non-existent recap", async () => {
       const notFoundRecapId = generateObjectIdString();
       await request(app)
         .delete(`/recaps/${notFoundRecapId}`)
@@ -189,7 +189,7 @@ describe("Recaps Routes", () => {
         });
     });
 
-    test("should return 200 with deleted recap after deleting recap", async () => {
+    test("should successfully delete an existing recap", async () => {
       const validOtherRecap = {
         kind: "Other",
         bulletPoints: [],

--- a/packages/backend/src/recaps/recaps.routes.ts
+++ b/packages/backend/src/recaps/recaps.routes.ts
@@ -20,6 +20,9 @@ const RecapsRoutes = {
       RecapsController.updateRecap,
     );
 
+    // DELETE /recaps/:recapId
+    this.router.delete("/:recapId", authMiddleware, RecapsController.deleteRecap);
+
     return this.router;
   },
 };


### PR DESCRIPTION
Resolves #59 in implementing DELETE /recaps/:recapId endpoint to delete a recap
Added stricter matching user id checks that would lead to 404 errors and also general 404 resource not found checks