### PR TITLE
[#61] Implemented GET /recaps/:recapId endpoint to retrieve recap details

### DIFF
--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -73,6 +73,96 @@ describe("Recaps Controller", () => {
     });
   });
 
+  describe("When reading a recap's details", () => {
+    test("should return 200 status with recap details on success", async () => {
+      const foundRecap: Recap = {
+        kind: "Skills",
+        proficiency: "Advanced",
+        bulletPoints: [],
+        title: "Skills Title",
+        userId,
+      };
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdAndUserIdSpy = (jest.spyOn(
+        RecapsDao,
+        "findRecapByIdAndUserId",
+      ) as jest.SpyInstance).mockImplementation(() => foundRecap);
+
+      await RecapsController.getRecapDetails(req, res);
+
+      expect(findRecapByIdAndUserIdSpy).toHaveBeenCalledWith({ recapId, userId });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(foundRecap);
+
+      findRecapByIdAndUserIdSpy.mockRestore();
+    });
+
+    test("should return 404 status with message on unmatched recap id", async () => {
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdAndUserIdSpy = (jest.spyOn(
+        RecapsDao,
+        "findRecapByIdAndUserId",
+      ) as jest.SpyInstance).mockImplementation(() => null);
+
+      await RecapsController.getRecapDetails(req, res);
+
+      expect(findRecapByIdAndUserIdSpy).toHaveBeenCalledWith({ recapId, userId });
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to find matching recap details" });
+
+      findRecapByIdAndUserIdSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on find recap by id server error", async () => {
+      const req = mockRequestWithUser({
+        params: {
+          recapId,
+        },
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findRecapByIdAndUserIdSpy = (jest.spyOn(
+        RecapsDao,
+        "findRecapByIdAndUserId",
+      ) as jest.SpyInstance).mockImplementation(() => Promise.reject("500 error"));
+
+      await RecapsController.getRecapDetails(req, res);
+
+      expect(findRecapByIdAndUserIdSpy).toHaveBeenCalledWith({ recapId, userId });
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to find recap details" });
+
+      findRecapByIdAndUserIdSpy.mockRestore();
+    });
+  });
+
   describe("When updating a recap", () => {
     test("should return 200 status with updated recap data on success", async () => {
       const recap: Recap = {

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -20,6 +20,25 @@ const RecapsController = {
     }
   },
 
+  // async getAllRecaps(req: RequestWithUser, res: Response) {},
+
+  async getRecapDetails(req: RequestWithUser, res: Response) {
+    const currentUser = req.user;
+    const recapId = req.params.recapId;
+
+    try {
+      const foundRecap = await RecapsDao.findRecapByIdAndUserId({ recapId, userId: currentUser.id });
+
+      if (foundRecap) {
+        res.status(200).json(foundRecap);
+      } else {
+        res.status(404).json({ message: "Failed to find matching recap details" });
+      }
+    } catch (err) {
+      res.status(500).json({ message: "Failed to find recap details" });
+    }
+  },
+
   async updateRecap(req: RequestWithUser, res: Response) {
     const currentUser = req.user;
     const recapId = req.params.recapId;

--- a/packages/backend/src/recaps/recaps.dao.test.ts
+++ b/packages/backend/src/recaps/recaps.dao.test.ts
@@ -76,6 +76,25 @@ describe("Recaps Dao", () => {
     expect(actualFoundRecap.toObject()).toMatchObject(expectedFoundRecap);
   });
 
+  test("should find recap by id and user id", async () => {
+    const otherRecap: RecapOther = {
+      ...formBaseRecap(),
+      kind: "Other",
+      title: "Other Title",
+    };
+    const otherRecapModel = new RecapOtherModel(otherRecap);
+
+    await otherRecapModel.save();
+
+    const actualFoundRecap = await RecapsDao.findRecapByIdAndUserId({
+      recapId: otherRecapModel._id,
+      userId: userIdString,
+    });
+    const expectedFoundRecap = otherRecap;
+
+    expect(actualFoundRecap.toObject()).toMatchObject(expectedFoundRecap);
+  });
+
   test("should be able to create a work experience recap", async () => {
     const workExperienceRecap: RecapWorkExperience = {
       ...formBaseRecap(),

--- a/packages/backend/src/recaps/recaps.dao.ts
+++ b/packages/backend/src/recaps/recaps.dao.ts
@@ -21,6 +21,10 @@ const RecapsDao = {
     return RecapBaseModel.findById(recapId);
   },
 
+  findRecapByIdAndUserId({ recapId, userId }: { recapId: string; userId: string }) {
+    return RecapBaseModel.findOne({ userId, _id: recapId });
+  },
+
   createRecap(recap: Recap) {
     switch (recap.kind) {
       case "WorkExperience":

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -105,6 +105,71 @@ describe("Recaps Routes", () => {
     });
   });
 
+  describe("GET /recaps/:recapId", () => {
+    test("should fail to get recap details without proper authorization", async () => {
+      await request(app)
+        .get("/recaps/recapId")
+        .expect(401);
+    });
+
+    test("should fail to get recap details of recap that no longer exists", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      let otherRecapId;
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201)
+        .then(response => {
+          otherRecapId = response.body._id;
+        });
+
+      await request(app)
+        .delete(`/recaps/${otherRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200);
+
+      await request(app)
+        .get(`/recaps/${otherRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(404)
+        .then(response => {
+          expect(response.body).toMatchObject({ message: "Failed to find matching recap details" });
+        });
+    });
+
+    test("should get recap details of existing recap", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      let otherRecapId;
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201)
+        .then(response => {
+          otherRecapId = response.body._id;
+        });
+
+      await request(app)
+        .get(`/recaps/${otherRecapId}`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200)
+        .then(response => {
+          expect(response.body).toMatchObject(validOtherRecap);
+        });
+    });
+  });
+
   describe("PATCH /recaps/:recapId", () => {
     test("should fail to update recap without proper authorization", async () => {
       const validOtherRecap = {

--- a/packages/backend/src/recaps/recaps.routes.ts
+++ b/packages/backend/src/recaps/recaps.routes.ts
@@ -12,6 +12,9 @@ const RecapsRoutes = {
     // POST /recaps
     this.router.post("/", authMiddleware, validationMiddleware(RecapSchema, "body"), RecapsController.createRecap);
 
+    // GET /recaps/:recapId
+    this.router.get("/:recapId", authMiddleware, RecapsController.getRecapDetails);
+
     // PATCH /recaps/:recapId
     this.router.patch(
       "/:recapId",


### PR DESCRIPTION
Resolves #61 in implementing the recap details endpoint 