### PR TITLE
[#57] Implemented GET /recaps endpoint to get all recaps for a user

### DIFF
--- a/packages/backend/src/recaps/recaps.controller.test.ts
+++ b/packages/backend/src/recaps/recaps.controller.test.ts
@@ -73,6 +73,63 @@ describe("Recaps Controller", () => {
     });
   });
 
+  describe("When reading all recaps for a user", () => {
+    test("should return 200 status with recaps on success", async () => {
+      const foundRecaps: Recap[] = [
+        {
+          kind: "Skills",
+          proficiency: "Advanced",
+          bulletPoints: [],
+          title: "Skills Title",
+          userId,
+        },
+      ];
+      const req = mockRequestWithUser({
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findAllRecapsSpy = (jest.spyOn(RecapsDao, "findAllRecaps") as jest.SpyInstance).mockImplementation(
+        () => foundRecaps,
+      );
+
+      await RecapsController.getAllRecaps(req, res);
+
+      expect(findAllRecapsSpy).toHaveBeenCalledWith(userId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(foundRecaps);
+
+      findAllRecapsSpy.mockRestore();
+    });
+
+    test("should return 500 status with message on server error", async () => {
+      const req = mockRequestWithUser({
+        user: {
+          username: "user",
+          email: "user@test.com",
+          id: userId,
+        },
+      });
+      const res = mockResponse();
+      const findAllRecapsSpy = (jest.spyOn(RecapsDao, "findAllRecaps") as jest.SpyInstance).mockImplementation(() =>
+        Promise.reject("500 error"),
+      );
+
+      await RecapsController.getAllRecaps(req, res);
+
+      expect(findAllRecapsSpy).toHaveBeenCalledWith(userId);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: "Failed to find recaps for user" });
+
+      findAllRecapsSpy.mockRestore();
+    });
+  });
+
   describe("When reading a recap's details", () => {
     test("should return 200 status with recap details on success", async () => {
       const foundRecap: Recap = {

--- a/packages/backend/src/recaps/recaps.controller.ts
+++ b/packages/backend/src/recaps/recaps.controller.ts
@@ -20,7 +20,17 @@ const RecapsController = {
     }
   },
 
-  // async getAllRecaps(req: RequestWithUser, res: Response) {},
+  async getAllRecaps(req: RequestWithUser, res: Response) {
+    const currentUser = req.user;
+
+    try {
+      const foundRecaps = await RecapsDao.findAllRecaps(currentUser.id);
+
+      res.status(200).json(foundRecaps);
+    } catch (err) {
+      res.status(500).json({ message: "Failed to find recaps for user" });
+    }
+  },
 
   async getRecapDetails(req: RequestWithUser, res: Response) {
     const currentUser = req.user;

--- a/packages/backend/src/recaps/recaps.routes.test.ts
+++ b/packages/backend/src/recaps/recaps.routes.test.ts
@@ -105,6 +105,36 @@ describe("Recaps Routes", () => {
     });
   });
 
+  describe("GET /recaps", () => {
+    test("should fail to get all recaps without proper authorization", async () => {
+      await request(app)
+        .get(`/recaps`)
+        .expect(401);
+    });
+
+    test("should get all recaps for a user", async () => {
+      const validOtherRecap = {
+        kind: "Other",
+        bulletPoints: [],
+        title: "Other Title",
+      };
+
+      await request(app)
+        .post("/recaps")
+        .set("Authorization", `Bearer ${authToken}`)
+        .send(validOtherRecap)
+        .expect(201);
+
+      await request(app)
+        .get(`/recaps`)
+        .set("Authorization", `Bearer ${authToken}`)
+        .expect(200)
+        .then(response => {
+          expect(response.body).toMatchObject([validOtherRecap]);
+        });
+    });
+  });
+
   describe("GET /recaps/:recapId", () => {
     test("should fail to get recap details without proper authorization", async () => {
       await request(app)

--- a/packages/backend/src/recaps/recaps.routes.ts
+++ b/packages/backend/src/recaps/recaps.routes.ts
@@ -12,6 +12,9 @@ const RecapsRoutes = {
     // POST /recaps
     this.router.post("/", authMiddleware, validationMiddleware(RecapSchema, "body"), RecapsController.createRecap);
 
+    // GET /recaps
+    this.router.get("/", authMiddleware, RecapsController.getAllRecaps);
+
     // GET /recaps/:recapId
     this.router.get("/:recapId", authMiddleware, RecapsController.getRecapDetails);
 


### PR DESCRIPTION
Resolves #57 in implementing /recaps endpoint to get all the recaps for a specific user