### PR TITLE
[#114] Integrate Delete Recap flows to all kind layouts

### DIFF
--- a/packages/frontend/src/pages/Recaps/components/Accomplishments/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Accomplishments/Layout/index.test.tsx
@@ -1,23 +1,24 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import AccomplishmentsLayout, { AccomplishmentsLayoutProps } from "./index";
+import { RecapAccomplishments } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
-const defaultProps: AccomplishmentsLayoutProps = {
-  recaps: [
-    {
-      title: "Promoted to Software Engineer 2 at SendGrid",
-      kind: "Accomplishments",
-      userId: "userId",
-      _id: "accomplishmentsId",
-      type: "Career",
-      bulletPoints: [
-        "Led migration of manual frontend deployments and hosting on on-prem nginx servers to AWS S3 and CloudFront with Terraform and Buildkite for CICD",
-        "Contributed to the development and pushed the final release of the redesigned Email Activity in Backbone/Marionette",
-        "Led the transition from an in-house Ruby Selenium solution to WebdriverIO and finally to Cypress for E2E tests",
-      ],
-      startDate: new Date("2018/10/20").toISOString(),
-    },
+const sampleRecapAccomplishments: RecapAccomplishments = {
+  title: "Promoted to Software Engineer 2 at SendGrid",
+  kind: "Accomplishments",
+  userId: "userId",
+  _id: "accomplishmentsId",
+  type: "Career",
+  bulletPoints: [
+    "Led migration of manual frontend deployments and hosting on on-prem nginx servers to AWS S3 and CloudFront with Terraform and Buildkite for CICD",
+    "Contributed to the development and pushed the final release of the redesigned Email Activity in Backbone/Marionette",
+    "Led the transition from an in-house Ruby Selenium solution to WebdriverIO and finally to Cypress for E2E tests",
   ],
+  startDate: new Date("2018/10/20").toISOString(),
+};
+const defaultProps: AccomplishmentsLayoutProps = {
+  recaps: [sampleRecapAccomplishments],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -51,5 +52,49 @@ describe("<AccomplishmentsLayout />", () => {
     expect(queryByTestId("accomplishmentsEmptyCard")).toBeNull();
 
     expect(getByTestId("accomplishmentsRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <AccomplishmentsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapAccomplishments));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Accomplishments Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <AccomplishmentsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Accomplishments Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Accomplishments/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Accomplishments/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import AccomplishmentsEmptyCard from "../EmptyCard";
 import AccomplishmentsRecap from "../Recap";
-import { RecapAccomplishments } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapAccomplishments } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface AccomplishmentsLayoutProps extends RecapLayoutProps {
   recaps: RecapAccomplishments[];
@@ -19,11 +30,51 @@ const AccomplishmentsLayout: React.FC<AccomplishmentsLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Accomplishments"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Accomplishments"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Accomplishments</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const AccomplishmentsLayout: React.FC<AccomplishmentsLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Accomplishments"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Accomplishments"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const AccomplishmentsLayout: React.FC<AccomplishmentsLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="accomplishmentsRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/Education/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Education/Layout/index.test.tsx
@@ -1,27 +1,28 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import EducationLayout, { EducationLayoutProps } from "./index";
+import { RecapEducation } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
-const defaultProps: EducationLayoutProps = {
-  recaps: [
-    {
-      kind: "Education",
-      userId: "userId",
-      _id: "educationId",
-      bulletPoints: [
-        "Upsilon Pi Epsilon Computer Science Honor Society",
-        "Alpha Phi Sigma Honor Society",
-        "Daily Bruin Web Development Intern",
-      ],
-      startDate: new Date("2013/10/01").toISOString(),
-      endDate: new Date("2017/06/20").toISOString(),
-      school: "University of California, Los Angeles",
-      location: "Los Angeles, CA",
-      degree: "Bachelor of Science",
-      fieldOfStudy: "Computer Science",
-      grade: "Alumnus",
-    },
+const sampleRecapEducation: RecapEducation = {
+  kind: "Education",
+  userId: "userId",
+  _id: "educationId",
+  bulletPoints: [
+    "Upsilon Pi Epsilon Computer Science Honor Society",
+    "Alpha Phi Sigma Honor Society",
+    "Daily Bruin Web Development Intern",
   ],
+  startDate: new Date("2013/10/01").toISOString(),
+  endDate: new Date("2017/06/20").toISOString(),
+  school: "University of California, Los Angeles",
+  location: "Los Angeles, CA",
+  degree: "Bachelor of Science",
+  fieldOfStudy: "Computer Science",
+  grade: "Alumnus",
+};
+const defaultProps: EducationLayoutProps = {
+  recaps: [sampleRecapEducation],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -51,5 +52,49 @@ describe("<EducationLayout />", () => {
     expect(queryByTestId("educationEmptyCard")).toBeNull();
 
     expect(getByTestId("educationRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <EducationLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapEducation));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Education Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <EducationLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Education Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Education/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Education/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import EducationEmptyCard from "../EmptyCard";
 import EducationRecap from "../Recap";
-import { RecapEducation } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapEducation } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface EducationLayoutProps extends RecapLayoutProps {
   recaps: RecapEducation[];
@@ -19,11 +30,51 @@ const EducationLayout: React.FC<EducationLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Education"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Education"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Education</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const EducationLayout: React.FC<EducationLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Education"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Education"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const EducationLayout: React.FC<EducationLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="educationRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/Organizations/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Organizations/Layout/index.test.tsx
@@ -1,24 +1,25 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import OrganizationsLayout, { OrganizationsLayoutProps } from "./index";
+import { RecapOrganizations } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
-const defaultProps: OrganizationsLayoutProps = {
-  recaps: [
-    {
-      organizationName: "Zeta Mu Beta",
-      positions: "Pledge Educator, Member",
-      location: "Long Beach, CA",
-      startDate: new Date("2014/12/13").toISOString(),
-      endDate: new Date("2016/03/31").toISOString(),
-      kind: "Organizations",
-      userId: "userId",
-      _id: "organizationsId",
-      bulletPoints: [
-        "Crossed into the organization in Fall 2014",
-        "Served as an active member for 2 years and as a pledge educator for the XI class",
-      ],
-    },
+const sampleRecapOrganizations: RecapOrganizations = {
+  organizationName: "Zeta Mu Beta",
+  positions: "Pledge Educator, Member",
+  location: "Long Beach, CA",
+  startDate: new Date("2014/12/13").toISOString(),
+  endDate: new Date("2016/03/31").toISOString(),
+  kind: "Organizations",
+  userId: "userId",
+  _id: "organizationsId",
+  bulletPoints: [
+    "Crossed into the organization in Fall 2014",
+    "Served as an active member for 2 years and as a pledge educator for the XI class",
   ],
+};
+const defaultProps: OrganizationsLayoutProps = {
+  recaps: [sampleRecapOrganizations],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -52,5 +53,49 @@ describe("<OrganizationsLayout />", () => {
     expect(queryByTestId("organizationsEmptyCard")).toBeNull();
 
     expect(getByTestId("organizationsRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <OrganizationsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapOrganizations));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Organizations Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <OrganizationsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Organizations Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Organizations/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Organizations/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import OrganizationsEmptyCard from "../EmptyCard";
 import OrganizationsRecap from "../Recap";
-import { RecapOrganizations } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapOrganizations } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface OrganizationsLayoutProps extends RecapLayoutProps {
   recaps: RecapOrganizations[];
@@ -19,11 +30,51 @@ const OrganizationsLayout: React.FC<OrganizationsLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Organizations"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Organizations"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Organizations</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const OrganizationsLayout: React.FC<OrganizationsLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Organizations"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Organizations"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const OrganizationsLayout: React.FC<OrganizationsLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="organizationsRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/Other/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Other/Layout/index.test.tsx
@@ -1,19 +1,20 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import OtherLayout, { OtherLayoutProps } from "./index";
+import { RecapOther } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
+const sampleRecapOther: RecapOther = {
+  title: "Finished reading Clean Code book!",
+  kind: "Other",
+  userId: "userId",
+  _id: "otherId",
+  startDate: new Date("2017/10/20").toISOString(),
+  endDate: new Date("2017/12/20").toISOString(),
+  bulletPoints: ["Learned about how to write cleaner and more maintainable code", "Improved with code reviews"],
+};
 const defaultProps: OtherLayoutProps = {
-  recaps: [
-    {
-      title: "Finished reading Clean Code book!",
-      kind: "Other",
-      userId: "userId",
-      _id: "otherId",
-      startDate: new Date("2017/10/20").toISOString(),
-      endDate: new Date("2017/12/20").toISOString(),
-      bulletPoints: ["Learned about how to write cleaner and more maintainable code", "Improved with code reviews"],
-    },
-  ],
+  recaps: [sampleRecapOther],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -43,5 +44,49 @@ describe("<OtherLayout />", () => {
     expect(queryByTestId("otherEmptyCard")).toBeNull();
 
     expect(getByTestId("otherRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <OtherLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapOther));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Other Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <OtherLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Other Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Other/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Other/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import OtherEmptyCard from "../EmptyCard";
 import OtherRecap from "../Recap";
-import { RecapOther } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapOther } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface OtherLayoutProps extends RecapLayoutProps {
   recaps: RecapOther[];
@@ -19,11 +30,51 @@ const OtherLayout: React.FC<OtherLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Other"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Other"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Other</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const OtherLayout: React.FC<OtherLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Other"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Other"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const OtherLayout: React.FC<OtherLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="otherRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/Publications/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Publications/Layout/index.test.tsx
@@ -1,22 +1,23 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import PublicationsLayout, { PublicationsLayoutProps } from "./index";
+import { RecapPublications } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
+const sampleRecapPublications: RecapPublications = {
+  title: "Mindfulness-based Interventions for those with PTSD",
+  kind: "Publications",
+  coauthors: "Gingin D.",
+  userId: "userId",
+  _id: "publicationsId",
+  type: "Journal",
+  bulletPoints: ["Providing meditation and cognitive behavioral therapy techniques for those with PTSD"],
+  publisher: "UCI Psychology",
+  startDate: new Date("2020/10/20").toISOString(),
+  url: "http://psychology.journal.com",
+};
 const defaultProps: PublicationsLayoutProps = {
-  recaps: [
-    {
-      title: "Mindfulness-based Interventions for those with PTSD",
-      kind: "Publications",
-      coauthors: "Gingin D.",
-      userId: "userId",
-      _id: "publicationsId",
-      type: "Journal",
-      bulletPoints: ["Providing meditation and cognitive behavioral therapy techniques for those with PTSD"],
-      publisher: "UCI Psychology",
-      startDate: new Date("2020/10/20").toISOString(),
-      url: "http://psychology.journal.com",
-    },
-  ],
+  recaps: [sampleRecapPublications],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -50,5 +51,49 @@ describe("<PublicationsLayout />", () => {
     expect(queryByTestId("publicationsEmptyCard")).toBeNull();
 
     expect(getByTestId("publicationsRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <PublicationsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapPublications));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Publications Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <PublicationsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Publications Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Publications/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Publications/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import PublicationsEmptyCard from "../EmptyCard";
 import PublicationsRecap from "../Recap";
-import { RecapPublications } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapPublications } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface PublicationsLayoutProps extends RecapLayoutProps {
   recaps: RecapPublications[];
@@ -19,11 +30,51 @@ const PublicationsLayout: React.FC<PublicationsLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Publications"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Publications"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Publications</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const PublicationsLayout: React.FC<PublicationsLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Publications"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Publications"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const PublicationsLayout: React.FC<PublicationsLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="publicationsRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/RecapLayout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapLayout/index.tsx
@@ -97,7 +97,7 @@ export interface RecapLayoutProps extends CommonProps {
   onGoBackToLanding: () => void;
   onCreateRecapSuccess: (createdRecap: Recap) => void;
   onUpdateRecapSuccess: (updatedRecap: Recap) => void;
-  onDeleteRecapSuccess: (recapId: string) => void;
+  onDeleteRecapSuccess: (deletedRecap: Recap) => void;
 }
 
 export { Container, Header, HeaderTitle, HeaderDescription, Content };

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsAlerts.stories.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsAlerts.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import RecapsCreateSuccessAlert from "./RecapsCreateSuccessAlert";
+import RecapsCreateErrorAlert from "./RecapsCreateErrorAlert";
+import RecapsUpdateSuccessAlert from "./RecapsUpdateSuccessAlert";
+import RecapsUpdateErrorAlert from "./RecapsUpdateErrorAlert";
+import RecapsDeleteSuccessAlert from "./RecapsDeleteSuccessAlert";
+import RecapsDeleteErrorAlert from "./RecapsDeleteErrorAlert";
+
+const onHide = () => {
+  console.log("Hide alert!");
+};
+
+storiesOf("RecapsPage/Alerts", module)
+  .add("Create Success", () => <RecapsCreateSuccessAlert onHide={onHide} isShowing={true} kind="Work Experience" />)
+  .add("Create Error", () => <RecapsCreateErrorAlert onHide={onHide} isShowing={true} kind="Work Experience" />)
+  .add("Update Success", () => <RecapsUpdateSuccessAlert onHide={onHide} isShowing={true} kind="Work Experience" />)
+  .add("Update Error", () => <RecapsUpdateErrorAlert onHide={onHide} isShowing={true} kind="Work Experience" />)
+  .add("Delete Success", () => <RecapsDeleteSuccessAlert onHide={onHide} isShowing={true} kind="Work Experience" />)
+  .add("Delete Error", () => <RecapsDeleteErrorAlert onHide={onHide} isShowing={true} kind="Work Experience" />);

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsCreateErrorAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsCreateErrorAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsCreateErrorAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsCreateErrorAlert: React.FC<RecapsCreateErrorAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="danger"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      Something went wrong with adding a {kind} Recap! Please try again or let us know if there is an issue!
+    </Alert>
+  );
+};
+
+export default RecapsCreateErrorAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsCreateSuccessAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsCreateSuccessAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsCreateSuccessAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsCreateSuccessAlert: React.FC<RecapsCreateSuccessAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="success"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      You have successfully created a {kind} Recap!
+    </Alert>
+  );
+};
+
+export default RecapsCreateSuccessAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteErrorAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteErrorAlert.tsx
@@ -26,7 +26,7 @@ const RecapsDeleteErrorAlert: React.FC<RecapsDeleteErrorAlertProps> = ({
       className={className}
       {...passThroughProps}
     >
-      Something went wrong with deleting a {kind} Recap! Please try again or let us know if there is an issue!
+      Something went wrong with deleting the {kind} Recap! Please try again or let us know if there is an issue!
     </Alert>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteErrorAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteErrorAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsDeleteErrorAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsDeleteErrorAlert: React.FC<RecapsDeleteErrorAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="danger"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      Something went wrong with deleting a {kind} Recap! Please try again or let us know if there is an issue!
+    </Alert>
+  );
+};
+
+export default RecapsDeleteErrorAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteSuccessAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteSuccessAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsDeleteSuccessAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsDeleteSuccessAlert: React.FC<RecapsDeleteSuccessAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="success"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      You have successfully deleted a {kind} Recap!
+    </Alert>
+  );
+};
+
+export default RecapsDeleteSuccessAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteSuccessAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsDeleteSuccessAlert.tsx
@@ -26,7 +26,7 @@ const RecapsDeleteSuccessAlert: React.FC<RecapsDeleteSuccessAlertProps> = ({
       className={className}
       {...passThroughProps}
     >
-      You have successfully deleted a {kind} Recap!
+      You have successfully deleted the {kind} Recap!
     </Alert>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsUpdateErrorAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsUpdateErrorAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsUpdateErrorAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsUpdateErrorAlert: React.FC<RecapsUpdateErrorAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="danger"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      Something went wrong with updating a {kind} Recap! Please try again or let us know if there is an issue!
+    </Alert>
+  );
+};
+
+export default RecapsUpdateErrorAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsUpdateSuccessAlert.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/RecapsUpdateSuccessAlert.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Alert, { AlertProps } from "../../../../components/Alert";
+import { CommonProps } from "../../../../components/commonProps";
+import { RecapKind } from "../../recaps.interface";
+
+interface RecapsUpdateSuccessAlertProps extends CommonProps {
+  kind: RecapKind;
+  isShowing: AlertProps["isShowing"];
+  onHide: AlertProps["onHide"];
+}
+
+const RecapsUpdateSuccessAlert: React.FC<RecapsUpdateSuccessAlertProps> = ({
+  kind,
+  isShowing,
+  onHide,
+  testId = "",
+  className = "",
+  ...passThroughProps
+}) => {
+  return (
+    <Alert
+      variant="success"
+      isShowing={isShowing}
+      onHide={onHide}
+      testId={testId}
+      className={className}
+      {...passThroughProps}
+    >
+      You have successfully updated a {kind} Recap!
+    </Alert>
+  );
+};
+
+export default RecapsUpdateSuccessAlert;

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/index.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import RecapsCreateSuccessAlert from "./RecapsCreateSuccessAlert";
+import RecapsCreateErrorAlert from "./RecapsCreateErrorAlert";
+import RecapsUpdateSuccessAlert from "./RecapsUpdateSuccessAlert";
+import RecapsUpdateErrorAlert from "./RecapsUpdateErrorAlert";
+import RecapsDeleteSuccessAlert from "./RecapsDeleteSuccessAlert";
+import RecapsDeleteErrorAlert from "./RecapsDeleteErrorAlert";
+
+describe("<RecapAlerts />", () => {
+  test("should render all alerts without error", () => {
+    const { container } = render(
+      <div>
+        <RecapsCreateSuccessAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+        <RecapsCreateErrorAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+        <RecapsDeleteSuccessAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+        <RecapsDeleteErrorAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+        <RecapsUpdateSuccessAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+        <RecapsUpdateErrorAlert
+          kind="Education"
+          isShowing={true}
+          onHide={() => {}}
+          className="extra-class"
+          testId="testId"
+        />
+      </div>,
+    );
+  });
+});

--- a/packages/frontend/src/pages/Recaps/components/RecapsAlerts/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsAlerts/index.tsx
@@ -1,0 +1,15 @@
+import RecapsCreateSuccessAlert from "./RecapsCreateSuccessAlert";
+import RecapsCreateErrorAlert from "./RecapsCreateErrorAlert";
+import RecapsUpdateSuccessAlert from "./RecapsUpdateSuccessAlert";
+import RecapsUpdateErrorAlert from "./RecapsUpdateErrorAlert";
+import RecapsDeleteSuccessAlert from "./RecapsDeleteSuccessAlert";
+import RecapsDeleteErrorAlert from "./RecapsDeleteErrorAlert";
+
+export {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+};

--- a/packages/frontend/src/pages/Recaps/components/RecapsConfirmDeleteModal/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsConfirmDeleteModal/index.tsx
@@ -33,7 +33,7 @@ const RecapsConfirmDeleteModal: React.FC<RecapsConfirmDeleteModalProps> = ({
         </Button>
         <Button type="button" variant="primary" onClick={onClickConfirmDelete} loading={isProcessingDelete}>
           {isProcessingDelete && <>Deleting...</>}
-          {!isProcessingDelete && <>Delete</>}
+          {!isProcessingDelete && <>Confirm Delete</>}
         </Button>
       </div>
     </CenterModal>

--- a/packages/frontend/src/pages/Recaps/components/RecapsConfirmDeleteModal/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/RecapsConfirmDeleteModal/index.tsx
@@ -31,7 +31,7 @@ const RecapsConfirmDeleteModal: React.FC<RecapsConfirmDeleteModalProps> = ({
         <Button type="button" variant="secondary" onClick={onHide} className="mr-2">
           Cancel
         </Button>
-        <Button type="button" variant="primary" onClick={onClickConfirmDelete} loading={isProcessingDelete}>
+        <Button type="button" variant="danger" onClick={onClickConfirmDelete} loading={isProcessingDelete}>
           {isProcessingDelete && <>Deleting...</>}
           {!isProcessingDelete && <>Confirm Delete</>}
         </Button>

--- a/packages/frontend/src/pages/Recaps/components/References/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/References/Layout/index.test.tsx
@@ -1,23 +1,24 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import ReferencesLayout, { ReferencesLayoutProps } from "./index";
+import { RecapReferences } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
-const defaultProps: ReferencesLayoutProps = {
-  recaps: [
-    {
-      title: "Andrew C. - Product Manager",
-      kind: "References",
-      userId: "userId",
-      _id: "referencesId",
-      company: "Sandia National Laboratories",
-      bulletPoints: [
-        "Worked under Andrew in building a Node.js, MongoDB, Neo4J bitcoin transaction visualization and classification prototype with D3.js sankey flows",
-        "Mentored by Ethan C. and worked with Steven R. in building out the frontend and parts of the backend",
-      ],
-      phoneNumber: "555-555-5555",
-      email: "ac@sandia.gov",
-    },
+const sampleRecapReferences: RecapReferences = {
+  title: "Andrew C. - Product Manager",
+  kind: "References",
+  userId: "userId",
+  _id: "referencesId",
+  company: "Sandia National Laboratories",
+  bulletPoints: [
+    "Worked under Andrew in building a Node.js, MongoDB, Neo4J bitcoin transaction visualization and classification prototype with D3.js sankey flows",
+    "Mentored by Ethan C. and worked with Steven R. in building out the frontend and parts of the backend",
   ],
+  phoneNumber: "555-555-5555",
+  email: "ac@sandia.gov",
+};
+const defaultProps: ReferencesLayoutProps = {
+  recaps: [sampleRecapReferences],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -47,5 +48,49 @@ describe("<ReferencesLayout />", () => {
     expect(queryByTestId("referencesEmptyCard")).toBeNull();
 
     expect(getByTestId("referencesRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <ReferencesLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapReferences));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the References Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <ReferencesLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the References Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/References/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/References/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import ReferencesEmptyCard from "../EmptyCard";
 import ReferencesRecap from "../Recap";
-import { RecapReferences } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapReferences } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface ReferencesLayoutProps extends RecapLayoutProps {
   recaps: RecapReferences[];
@@ -19,11 +30,51 @@ const ReferencesLayout: React.FC<ReferencesLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="References"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="References"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>References</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const ReferencesLayout: React.FC<ReferencesLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="References"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="References"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const ReferencesLayout: React.FC<ReferencesLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="referencesRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/SideProjects/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/SideProjects/Layout/index.test.tsx
@@ -1,20 +1,21 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import SideProjectsLayout, { SideProjectsLayoutProps } from "./index";
+import { RecapSideProjects } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
+const sampleRecapSideProjects: RecapSideProjects = {
+  title: "Zeta Mu Beta Website",
+  creators: "Alfred Lucero and Regine Deguzman",
+  startDate: new Date("2016/11/01").toISOString(),
+  endDate: new Date("2016/12/31").toISOString(),
+  kind: "Side Projects",
+  userId: "userId",
+  _id: "sideProjectsId",
+  bulletPoints: ["Created fraternity website on www.zetamubeta.org with MEAN stack"],
+};
 const defaultProps: SideProjectsLayoutProps = {
-  recaps: [
-    {
-      title: "Zeta Mu Beta Website",
-      creators: "Alfred Lucero and Regine Deguzman",
-      startDate: new Date("2016/11/01").toISOString(),
-      endDate: new Date("2016/12/31").toISOString(),
-      kind: "Side Projects",
-      userId: "userId",
-      _id: "sideProjectsId",
-      bulletPoints: ["Created fraternity website on www.zetamubeta.org with MEAN stack"],
-    },
-  ],
+  recaps: [sampleRecapSideProjects],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -48,5 +49,49 @@ describe("<SideProjectsLayout />", () => {
     expect(queryByTestId("sideProjectsEmptyCard")).toBeNull();
 
     expect(getByTestId("sideProjectsRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <SideProjectsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapSideProjects));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Side Projects Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <SideProjectsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Side Projects Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/SideProjects/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/SideProjects/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import SideProjectsEmptyCard from "../EmptyCard";
 import SideProjectsRecap from "../Recap";
-import { RecapSideProjects } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapSideProjects } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface SideProjectsLayoutProps extends RecapLayoutProps {
   recaps: RecapSideProjects[];
@@ -19,11 +30,51 @@ const SideProjectsLayout: React.FC<SideProjectsLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Side Projects"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Side Projects"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Side Projects</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const SideProjectsLayout: React.FC<SideProjectsLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Side Projects"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Side Projects"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const SideProjectsLayout: React.FC<SideProjectsLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="sideProjectsRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/Skills/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Skills/Layout/index.test.tsx
@@ -1,21 +1,22 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import SkillsLayout, { SkillsLayoutProps } from "./index";
+import { RecapSkills } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
 
-const defaultProps: SkillsLayoutProps = {
-  recaps: [
-    {
-      title: "Tagalog",
-      kind: "Skills",
-      userId: "userId",
-      _id: "skillsId",
-      proficiency: "Intermediate",
-      bulletPoints: [
-        "Not a fluent speaker but can understand every day Tagalog speaking well",
-        "Can speak some Tagalog here and there but struggle with grammar",
-      ],
-    },
+const sampleRecapSkills: RecapSkills = {
+  title: "Tagalog",
+  kind: "Skills",
+  userId: "userId",
+  _id: "skillsId",
+  proficiency: "Intermediate",
+  bulletPoints: [
+    "Not a fluent speaker but can understand every day Tagalog speaking well",
+    "Can speak some Tagalog here and there but struggle with grammar",
   ],
+};
+const defaultProps: SkillsLayoutProps = {
+  recaps: [sampleRecapSkills],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -45,5 +46,49 @@ describe("<SkillsLayout />", () => {
     expect(queryByTestId("skillsEmptyCard")).toBeNull();
 
     expect(getByTestId("skillsRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <SkillsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapSkills));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted the Skills Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <SkillsLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting the Skills Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/Skills/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/Skills/Layout/index.tsx
@@ -3,7 +3,18 @@ import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import SkillsEmptyCard from "../EmptyCard";
 import SkillsRecap from "../Recap";
-import { RecapSkills } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapSkills } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface SkillsLayoutProps extends RecapLayoutProps {
   recaps: RecapSkills[];
@@ -19,11 +30,51 @@ const SkillsLayout: React.FC<SkillsLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Skills"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Skills"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Skills</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +92,18 @@ const SkillsLayout: React.FC<SkillsLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Skills"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Skills"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +123,20 @@ const SkillsLayout: React.FC<SkillsLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="skillsRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.test.tsx
@@ -74,7 +74,7 @@ describe("<WorkExperienceLayout />", () => {
     await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
 
     expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
-    const successAlert = await findByText("You have successfully deleted a Work Experience Recap!");
+    const successAlert = await findByText("You have successfully deleted the Work Experience Recap!");
     expect(successAlert).toBeVisible();
   });
 
@@ -95,7 +95,7 @@ describe("<WorkExperienceLayout />", () => {
     await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
 
     expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
-    const errorAlert = await findByText("Something went wrong with deleting a Work Experience Recap!", {
+    const errorAlert = await findByText("Something went wrong with deleting the Work Experience Recap!", {
       exact: false,
     });
     expect(errorAlert).toBeVisible();

--- a/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.test.tsx
@@ -1,25 +1,27 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent, waitForElementToBeRemoved } from "@testing-library/react";
 import WorkExperienceLayout, { WorkExperienceLayoutProps } from "./index";
+import { RecapWorkExperience } from "../../../recaps.interface";
+import * as RecapsService from "../../../recaps.service";
+
+const sampleRecapWorkExperience: RecapWorkExperience = {
+  kind: "Work Experience",
+  userId: "userId",
+  _id: "workExperienceId",
+  bulletPoints: [
+    "Worked on the Culdevate start up seriously",
+    "Getting better at making REST API endpoints",
+    "Improving interviewing and mentoring skills",
+  ],
+  startDate: new Date("2020/01/17").toISOString(),
+  title: "Lead Software Engineer",
+  company: "Culdevate",
+  location: "Long Beach, CA",
+  employmentType: "Self-Employed",
+};
 
 const defaultProps: WorkExperienceLayoutProps = {
-  recaps: [
-    {
-      kind: "Work Experience",
-      userId: "userId",
-      _id: "workExperienceId",
-      bulletPoints: [
-        "Worked on the Culdevate start up seriously",
-        "Getting better at making REST API endpoints",
-        "Improving interviewing and mentoring skills",
-      ],
-      startDate: new Date("2020/01/17").toISOString(),
-      title: "Lead Software Engineer",
-      company: "Culdevate",
-      location: "Long Beach, CA",
-      employmentType: "Self-Employed",
-    },
-  ],
+  recaps: [sampleRecapWorkExperience],
   onGoBackToLanding: () => {},
   onCreateRecapSuccess: () => {},
   onUpdateRecapSuccess: () => {},
@@ -53,5 +55,49 @@ describe("<WorkExperienceLayout />", () => {
     expect(queryByTestId("workExperienceEmptyCard")).toBeNull();
 
     expect(getByTestId("workExperienceRecap")).toBeVisible();
+  });
+
+  test("should show the success alert after deleting a recap successfully", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <WorkExperienceLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.resolve(sampleRecapWorkExperience));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).toHaveBeenCalled();
+    const successAlert = await findByText("You have successfully deleted a Work Experience Recap!");
+    expect(successAlert).toBeVisible();
+  });
+
+  test("should show the error alert after failing to delete a recap", async () => {
+    const onDeleteRecapSuccessMock = jest.fn();
+    const { getByText, queryByText, findByText } = render(
+      <WorkExperienceLayout {...defaultProps} onDeleteRecapSuccess={onDeleteRecapSuccessMock} />,
+    );
+
+    fireEvent.click(getByText("Delete"));
+
+    expect(getByText("Are you sure you want to delete this?")).toBeVisible();
+
+    jest.spyOn(RecapsService, "deleteRecap").mockImplementationOnce(() => Promise.reject({}));
+
+    fireEvent.click(getByText("Confirm Delete"));
+
+    await waitForElementToBeRemoved(() => queryByText("Are you sure you want to delete this?"));
+
+    expect(onDeleteRecapSuccessMock).not.toHaveBeenCalled();
+    const errorAlert = await findByText("Something went wrong with deleting a Work Experience Recap!", {
+      exact: false,
+    });
+    expect(errorAlert).toBeVisible();
   });
 });

--- a/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.tsx
@@ -1,13 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
 import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import WorkExperienceEmptyCard from "../EmptyCard";
 import WorkExperienceRecap from "../Recap";
-import { RecapWorkExperience } from "../../../recaps.interface";
+import RecapsConfirmDeleteModal from "../../RecapsConfirmDeleteModal";
+import {
+  RecapsCreateSuccessAlert,
+  RecapsCreateErrorAlert,
+  RecapsUpdateSuccessAlert,
+  RecapsUpdateErrorAlert,
+  RecapsDeleteSuccessAlert,
+  RecapsDeleteErrorAlert,
+} from "../../RecapsAlerts";
+import { Recap, RecapWorkExperience } from "../../../recaps.interface";
+import { useRecapsAlerts } from "../../../hooks/useRecapsAlerts";
+import { useDeleteRecap } from "../../../hooks/useDeleteRecap";
 
 export interface WorkExperienceLayoutProps extends RecapLayoutProps {
   recaps: RecapWorkExperience[];
 }
+
+// TODO: custom hooks to make other pages' lives simpler
+// hook for useCreateRecap
+// hook for useUpdateRecap
 
 const WorkExperienceLayout: React.FC<WorkExperienceLayoutProps> = ({
   recaps,
@@ -19,11 +34,51 @@ const WorkExperienceLayout: React.FC<WorkExperienceLayoutProps> = ({
   testId = "",
   ...passThroughProps
 }) => {
+  const {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  } = useRecapsAlerts();
+
+  const {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  } = useDeleteRecap({
+    recaps,
+    onDeleteSuccess: (deletedRecap: Recap) => {
+      onDeleteRecapSuccess(deletedRecap);
+      showDeleteSuccessAlert();
+    },
+    onDeleteError: () => {
+      showDeleteErrorAlert();
+    },
+  });
+
   const hasRecaps = recaps.length > 0;
 
   if (!hasRecaps) {
     return (
       <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+        <RecapsDeleteSuccessAlert
+          isShowing={alertsState.isShowingDeleteSuccessAlert}
+          onHide={hideAlert}
+          kind="Work Experience"
+          className="mb-4"
+        />
+        <RecapsDeleteErrorAlert
+          isShowing={alertsState.isShowingDeleteErrorAlert}
+          onHide={hideAlert}
+          kind="Work Experience"
+          className="mb-4"
+        />
         <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
           <RecapLayout.HeaderTitle>Work Experience</RecapLayout.HeaderTitle>
         </RecapLayout.Header>
@@ -41,6 +96,18 @@ const WorkExperienceLayout: React.FC<WorkExperienceLayoutProps> = ({
 
   return (
     <RecapLayout.Container testId={testId} className={className} {...passThroughProps}>
+      <RecapsDeleteSuccessAlert
+        isShowing={alertsState.isShowingDeleteSuccessAlert}
+        onHide={hideAlert}
+        kind="Work Experience"
+        className="mb-4"
+      />
+      <RecapsDeleteErrorAlert
+        isShowing={alertsState.isShowingDeleteErrorAlert}
+        onHide={hideAlert}
+        kind="Work Experience"
+        className="mb-4"
+      />
       <RecapLayout.Header className="mb-8" onClickBack={onGoBackToLanding}>
         <RecapLayout.HeaderTitle
           onClickAdd={() => {
@@ -60,15 +127,20 @@ const WorkExperienceLayout: React.FC<WorkExperienceLayoutProps> = ({
             onEdit={() => {
               // TODO: open up this recap's edit modal
             }}
-            onDelete={() => {
-              // TODO: open up this recap's delete modal
-            }}
+            onDelete={onClickDeleteRecap}
             key={key}
             testId="workExperienceRecap"
             className="mb-4"
           />
         ))}
       </RecapLayout.Content>
+
+      <RecapsConfirmDeleteModal
+        isShowing={isShowingConfirmDeleteModal}
+        onHide={onHideConfirmDeleteModal}
+        isProcessingDelete={isProcessingDelete}
+        onClickConfirmDelete={onClickConfirmDelete}
+      />
     </RecapLayout.Container>
   );
 };

--- a/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.tsx
+++ b/packages/frontend/src/pages/Recaps/components/WorkExperience/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import * as RecapLayout from "../../RecapLayout";
 import { RecapLayoutProps } from "../../RecapLayout";
 import WorkExperienceEmptyCard from "../EmptyCard";

--- a/packages/frontend/src/pages/Recaps/hooks/useCreateRecap.ts
+++ b/packages/frontend/src/pages/Recaps/hooks/useCreateRecap.ts
@@ -1,0 +1,1 @@
+// TODO: implement this

--- a/packages/frontend/src/pages/Recaps/hooks/useDeleteRecap.ts
+++ b/packages/frontend/src/pages/Recaps/hooks/useDeleteRecap.ts
@@ -47,8 +47,7 @@ export const useDeleteRecap = ({ recaps, onDeleteSuccess, onDeleteError }: UseDe
 
     setIsProcessingDelete(true);
     deleteRecap(selectedRecap._id)
-      .then(response => {
-        const deletedRecap = response.data;
+      .then(deletedRecap => {
         setSelectedRecap(null);
         setIsProcessingDelete(false);
         setIsShowingConfirmDeleteModal(false);

--- a/packages/frontend/src/pages/Recaps/hooks/useDeleteRecap.ts
+++ b/packages/frontend/src/pages/Recaps/hooks/useDeleteRecap.ts
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { deleteRecap } from "../recaps.service";
+import { Recap } from "../recaps.interface";
+
+export interface UseDeleteRecapArgs {
+  recaps: Recap[];
+  onDeleteSuccess: (deletedRecap: Recap) => void;
+  onDeleteError: () => void;
+}
+
+export interface UseDeleteRecap {
+  isShowingConfirmDeleteModal: boolean;
+  isProcessingDelete: boolean;
+  onClickDeleteRecap: (e: React.MouseEvent) => void;
+  onClickConfirmDelete: () => void;
+  onHideConfirmDeleteModal: () => void;
+}
+
+export const useDeleteRecap = ({ recaps, onDeleteSuccess, onDeleteError }: UseDeleteRecapArgs): UseDeleteRecap => {
+  const [selectedRecap, setSelectedRecap] = useState<Recap | null>(null);
+
+  const [isShowingConfirmDeleteModal, setIsShowingConfirmDeleteModal] = useState(false);
+  const [isProcessingDelete, setIsProcessingDelete] = useState(false);
+
+  const onHideConfirmDeleteModal = () => {
+    setIsShowingConfirmDeleteModal(false);
+    setSelectedRecap(null);
+  };
+
+  const onClickDeleteRecap = (e: React.MouseEvent) => {
+    const recapId = e.currentTarget.id;
+
+    const newSelectedRecap = recaps.find(recap => recap._id === recapId);
+
+    if (!newSelectedRecap) {
+      return;
+    }
+
+    setSelectedRecap(newSelectedRecap);
+    setIsShowingConfirmDeleteModal(true);
+  };
+
+  const onClickConfirmDelete = () => {
+    if (!selectedRecap) {
+      return;
+    }
+
+    setIsProcessingDelete(true);
+    deleteRecap(selectedRecap._id)
+      .then(response => {
+        const deletedRecap = response.data;
+        setSelectedRecap(null);
+        setIsProcessingDelete(false);
+        setIsShowingConfirmDeleteModal(false);
+        onDeleteSuccess(deletedRecap);
+      })
+      .catch(() => {
+        setSelectedRecap(null);
+        setIsProcessingDelete(false);
+        setIsShowingConfirmDeleteModal(false);
+        onDeleteError();
+      });
+  };
+
+  return {
+    isShowingConfirmDeleteModal,
+    isProcessingDelete,
+    onClickDeleteRecap,
+    onClickConfirmDelete,
+    onHideConfirmDeleteModal,
+  };
+};

--- a/packages/frontend/src/pages/Recaps/hooks/useRecapsAlerts.ts
+++ b/packages/frontend/src/pages/Recaps/hooks/useRecapsAlerts.ts
@@ -1,0 +1,167 @@
+import React, { useReducer } from "react";
+
+export interface RecapsAlertsState {
+  isShowingCreateSuccessAlert: boolean;
+  isShowingCreateErrorAlert: boolean;
+  isShowingUpdateSuccessAlert: boolean;
+  isShowingUpdateErrorAlert: boolean;
+  isShowingDeleteSuccessAlert: boolean;
+  isShowingDeleteErrorAlert: boolean;
+}
+
+const initialRecapsAlertsState: RecapsAlertsState = {
+  isShowingCreateSuccessAlert: false,
+  isShowingCreateErrorAlert: false,
+  isShowingUpdateSuccessAlert: false,
+  isShowingUpdateErrorAlert: false,
+  isShowingDeleteSuccessAlert: false,
+  isShowingDeleteErrorAlert: false,
+};
+
+enum ActionTypes {
+  ShowCreateSuccessAlert = "showCreateSuccessAlert",
+  ShowCreateErrorAlert = "showCreateErrorAlert",
+  ShowUpdateSuccessAlert = "showUpdateSuccessAlert",
+  ShowUpdateErrorAlert = "showUpdateErrorAlert",
+  ShowDeleteSuccessAlert = "showDeleteSuccessAlert",
+  ShowDeleteErrorAlert = "showDeleteErrorAlert",
+  HideAlert = "hideAlert",
+}
+
+type RecapsAlertsAction = {
+  type: ActionTypes;
+};
+
+const reducer = (state: RecapsAlertsState, action: RecapsAlertsAction): RecapsAlertsState => {
+  switch (action.type) {
+    case ActionTypes.ShowCreateSuccessAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: true,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: false,
+      };
+    case ActionTypes.ShowCreateErrorAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: true,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: false,
+      };
+    case ActionTypes.ShowUpdateSuccessAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: true,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: false,
+      };
+    case ActionTypes.ShowUpdateErrorAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: true,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: false,
+      };
+    case ActionTypes.ShowDeleteSuccessAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: true,
+        isShowingDeleteErrorAlert: false,
+      };
+    case ActionTypes.ShowDeleteErrorAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: true,
+      };
+    case ActionTypes.HideAlert:
+      return {
+        ...state,
+        isShowingCreateSuccessAlert: false,
+        isShowingCreateErrorAlert: false,
+        isShowingUpdateSuccessAlert: false,
+        isShowingUpdateErrorAlert: false,
+        isShowingDeleteSuccessAlert: false,
+        isShowingDeleteErrorAlert: false,
+      };
+    default:
+      return state;
+  }
+};
+
+export interface UseRecapsAlerts {
+  alertsState: RecapsAlertsState;
+  showCreateSuccessAlert: () => void;
+  showCreateErrorAlert: () => void;
+  showUpdateSuccessAlert: () => void;
+  showUpdateErrorAlert: () => void;
+  showDeleteSuccessAlert: () => void;
+  showDeleteErrorAlert: () => void;
+  hideAlert: () => void;
+}
+
+export const useRecapsAlerts = (): UseRecapsAlerts => {
+  const [alertsState, dispatch] = useReducer<React.Reducer<RecapsAlertsState, RecapsAlertsAction>>(
+    reducer,
+    initialRecapsAlertsState,
+  );
+
+  const showCreateSuccessAlert = () => {
+    dispatch({ type: ActionTypes.ShowCreateSuccessAlert });
+  };
+
+  const showCreateErrorAlert = () => {
+    dispatch({ type: ActionTypes.ShowCreateSuccessAlert });
+  };
+
+  const showUpdateSuccessAlert = () => {
+    dispatch({ type: ActionTypes.ShowUpdateSuccessAlert });
+  };
+
+  const showUpdateErrorAlert = () => {
+    dispatch({ type: ActionTypes.ShowUpdateSuccessAlert });
+  };
+
+  const showDeleteSuccessAlert = () => {
+    dispatch({ type: ActionTypes.ShowDeleteSuccessAlert });
+  };
+
+  const showDeleteErrorAlert = () => {
+    dispatch({ type: ActionTypes.ShowDeleteErrorAlert });
+  };
+
+  const hideAlert = () => {
+    dispatch({ type: ActionTypes.HideAlert });
+  };
+
+  return {
+    alertsState,
+    showCreateSuccessAlert,
+    showCreateErrorAlert,
+    showUpdateSuccessAlert,
+    showUpdateErrorAlert,
+    showDeleteSuccessAlert,
+    showDeleteErrorAlert,
+    hideAlert,
+  };
+};

--- a/packages/frontend/src/pages/Recaps/hooks/useUpdateRecap.ts
+++ b/packages/frontend/src/pages/Recaps/hooks/useUpdateRecap.ts
@@ -1,0 +1,1 @@
+// TODO: implement this

--- a/packages/frontend/src/pages/Recaps/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/index.test.tsx
@@ -1,18 +1,19 @@
 import React from "react";
-import { fireEvent, render, waitForElement } from "@testing-library/react";
+import { fireEvent, render, waitForElement, waitForElementToBeRemoved } from "@testing-library/react";
 import Recaps from "./index";
 import * as RecapsService from "./recaps.service";
 
 describe("<Recaps />", () => {
-  test("should render the loading state when fetching recaps", () => {
+  test("should render the loading state when fetching recaps", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.reject({}));
     const { getByTestId } = render(<Recaps />);
 
     expect(getByTestId("recapsPageLoading")).toBeVisible();
+
+    await waitForElementToBeRemoved(() => getByTestId("recapsPageLoading"));
   });
 
   test("should show the error state after failing to fetch recaps", async () => {
-    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.reject({}));
-
     const { getByTestId } = render(<Recaps />);
 
     await waitForElement(() => getByTestId("recapsPageError"));

--- a/packages/frontend/src/pages/Recaps/index.test.tsx
+++ b/packages/frontend/src/pages/Recaps/index.test.tsx
@@ -1,0 +1,199 @@
+import React from "react";
+import { fireEvent, render, waitForElement } from "@testing-library/react";
+import Recaps from "./index";
+import * as RecapsService from "./recaps.service";
+
+describe("<Recaps />", () => {
+  test("should render the loading state when fetching recaps", () => {
+    const { getByTestId } = render(<Recaps />);
+
+    expect(getByTestId("recapsPageLoading")).toBeVisible();
+  });
+
+  test("should show the error state after failing to fetch recaps", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.reject({}));
+
+    const { getByTestId } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPageError"));
+  });
+
+  test("should show the landing list cards after successfully fetching recaps", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.reject({}));
+
+    const { getByTestId } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPageError"));
+  });
+
+  test("should go to the Work Experience layout and be able to go back after clicking the Work Experience card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Work Experience"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Work Experience")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Education layout and be able to go back after clicking Education card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Education"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Education")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to Accomplishments layout and be able to go back after clicking the Accomplishments card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Accomplishments"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Accomplishments")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Skills layout and be able to go back after clicking the Skills card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Skills"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Skills")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Organizations layout and be able to go back after clicking the Organizations card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Organizations"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Organizations")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Side Projects layout and be able to go back after clicking the Side Projects card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Side Projects"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Side Projects")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Publications layout and be able to go back after clicking the Publications card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Publications"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Publications")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the References layout and be able to go back after clicking the References card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getByText, getAllByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("References"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("References")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+
+  test("should go to the Other layout and be able to go back after clicking the Other card", async () => {
+    jest.spyOn(RecapsService, "getRecaps").mockImplementationOnce(() => Promise.resolve([]));
+
+    const { getByTestId, getAllByText, getByText, findByText } = render(<Recaps />);
+
+    await waitForElement(() => getByTestId("recapsPage"));
+
+    fireEvent.click(getByText("Other"));
+
+    const addRecapButton = await findByText("Add a Recap");
+    expect(addRecapButton).toBeVisible();
+    expect(getAllByText("Other")).toBeTruthy();
+
+    fireEvent.click(getByText("Back to Recaps"));
+    const viewAllButton = await findByText("View All");
+    expect(viewAllButton).toBeVisible();
+    expect(getByText("Recaps")).toBeVisible();
+  });
+});

--- a/packages/frontend/src/pages/Recaps/index.tsx
+++ b/packages/frontend/src/pages/Recaps/index.tsx
@@ -31,7 +31,6 @@ import {
   RecapOther,
   Recap,
 } from "./recaps.interface";
-import { ResponseError } from "../../interfaces/responseError.interface";
 
 /*
   State Management:
@@ -135,7 +134,9 @@ enum ActionTypes {
   GetRecapsRequest = "getRecapsRequest",
   GetRecapsSuccess = "getRecapsSuccess",
   GetRecapsFailure = "getRecapsFailure",
-  // TODO: add update/add/delete for each recap type
+  CreateRecapSuccess = "createRecapSuccess",
+  UpdateRecapSuccess = "updateRecapSuccess",
+  DeleteRecapSuccess = "deleteRecapSuccess",
 }
 
 type RecapsPageAction =
@@ -148,6 +149,18 @@ type RecapsPageAction =
     }
   | {
       type: ActionTypes.GetRecapsFailure;
+    }
+  | {
+      type: ActionTypes.CreateRecapSuccess;
+      payload: Recap;
+    }
+  | {
+      type: ActionTypes.UpdateRecapSuccess;
+      payload: Recap;
+    }
+  | {
+      type: ActionTypes.DeleteRecapSuccess;
+      payload: Recap;
     };
 
 const recapsAdapter = (recaps: Recap[]): RecapsMap => {
@@ -212,6 +225,18 @@ const recapsAdapter = (recaps: Recap[]): RecapsMap => {
   return recapsMap;
 };
 
+function createRecapForList<RecapType>(createdRecap: RecapType, recaps: RecapType[]): RecapType[] {
+  return [...recaps, createdRecap];
+}
+function updateRecapInList(updatedRecap: Recap, recaps: Recap[]): Recap[] {
+  return recaps.map(recap => {
+    return recap._id === updatedRecap._id ? updatedRecap : recap;
+  });
+}
+function deleteRecapFromList(deletedRecap: Recap, recaps: Recap[]): Recap[] {
+  return recaps.filter(recap => (recap._id !== deletedRecap._id ? true : false));
+}
+
 const recapsPageReducer = (state: RecapsPageState, action: RecapsPageAction): RecapsPageState => {
   switch (action.type) {
     case ActionTypes.GetRecapsRequest: {
@@ -237,6 +262,258 @@ const recapsPageReducer = (state: RecapsPageState, action: RecapsPageAction): Re
         isFetchingRecaps: false,
         isFetchRecapsError: true,
       };
+    }
+    case ActionTypes.CreateRecapSuccess: {
+      const createdRecap = action.payload;
+
+      switch (createdRecap.kind) {
+        case "Work Experience":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              workExperience: createRecapForList(createdRecap, state.recapsMap.workExperience),
+            },
+          };
+        case "Education":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              education: createRecapForList(createdRecap, state.recapsMap.education),
+            },
+          };
+        case "Accomplishments":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              accomplishments: createRecapForList(createdRecap, state.recapsMap.accomplishments),
+            },
+          };
+        case "Organizations":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              organizations: createRecapForList(createdRecap, state.recapsMap.organizations),
+            },
+          };
+        case "Skills":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              skills: createRecapForList(createdRecap, state.recapsMap.skills),
+            },
+          };
+        case "Side Projects":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              sideProjects: createRecapForList(createdRecap, state.recapsMap.sideProjects),
+            },
+          };
+        case "Publications":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              publications: createRecapForList(createdRecap, state.recapsMap.publications),
+            },
+          };
+        case "References":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              references: createRecapForList(createdRecap, state.recapsMap.references),
+            },
+          };
+        case "Other":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              other: createRecapForList(createdRecap, state.recapsMap.other),
+            },
+          };
+        default:
+          console.error("Invalid recap kind for ", createdRecap);
+          return state;
+      }
+    }
+    case ActionTypes.UpdateRecapSuccess: {
+      const updatedRecap = action.payload;
+
+      switch (updatedRecap.kind) {
+        case "Work Experience":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              workExperience: updateRecapInList(updatedRecap, state.recapsMap.workExperience) as RecapWorkExperience[],
+            },
+          };
+        case "Education":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              education: updateRecapInList(updatedRecap, state.recapsMap.education) as RecapEducation[],
+            },
+          };
+        case "Accomplishments":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              accomplishments: updateRecapInList(
+                updatedRecap,
+                state.recapsMap.accomplishments,
+              ) as RecapAccomplishments[],
+            },
+          };
+        case "Organizations":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              organizations: updateRecapInList(updatedRecap, state.recapsMap.organizations) as RecapOrganizations[],
+            },
+          };
+        case "Skills":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              skills: updateRecapInList(updatedRecap, state.recapsMap.skills) as RecapSkills[],
+            },
+          };
+        case "Side Projects":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              sideProjects: updateRecapInList(updatedRecap, state.recapsMap.sideProjects) as RecapSideProjects[],
+            },
+          };
+        case "Publications":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              publications: updateRecapInList(updatedRecap, state.recapsMap.publications) as RecapPublications[],
+            },
+          };
+        case "References":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              references: updateRecapInList(updatedRecap, state.recapsMap.references) as RecapReferences[],
+            },
+          };
+        case "Other":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              other: updateRecapInList(updatedRecap, state.recapsMap.other) as RecapOther[],
+            },
+          };
+        default:
+          console.error("Invalid recap kind for ", updatedRecap);
+          return state;
+      }
+    }
+    case ActionTypes.DeleteRecapSuccess: {
+      const deletedRecap = action.payload;
+
+      switch (deletedRecap.kind) {
+        case "Work Experience":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              workExperience: deleteRecapFromList(
+                deletedRecap,
+                state.recapsMap.workExperience,
+              ) as RecapWorkExperience[],
+            },
+          };
+        case "Education":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              education: deleteRecapFromList(deletedRecap, state.recapsMap.education) as RecapEducation[],
+            },
+          };
+        case "Accomplishments":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              accomplishments: deleteRecapFromList(
+                deletedRecap,
+                state.recapsMap.accomplishments,
+              ) as RecapAccomplishments[],
+            },
+          };
+        case "Organizations":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              organizations: deleteRecapFromList(deletedRecap, state.recapsMap.organizations) as RecapOrganizations[],
+            },
+          };
+        case "Skills":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              skills: deleteRecapFromList(deletedRecap, state.recapsMap.skills) as RecapSkills[],
+            },
+          };
+        case "Side Projects":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              sideProjects: deleteRecapFromList(deletedRecap, state.recapsMap.sideProjects) as RecapSideProjects[],
+            },
+          };
+        case "Publications":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              publications: deleteRecapFromList(deletedRecap, state.recapsMap.publications) as RecapPublications[],
+            },
+          };
+        case "References":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              references: deleteRecapFromList(deletedRecap, state.recapsMap.references) as RecapReferences[],
+            },
+          };
+        case "Other":
+          return {
+            ...state,
+            recapsMap: {
+              ...state.recapsMap,
+              other: deleteRecapFromList(deletedRecap, state.recapsMap.other) as RecapOther[],
+            },
+          };
+        default:
+          console.error("Invalid recap kind for ", deletedRecap);
+          return state;
+      }
     }
     default:
       return state;
@@ -280,6 +557,16 @@ const RecapsPage = () => {
 
   useEffect(fetchRecaps, []);
 
+  const onCreateRecapSuccess = (createdRecap: Recap) => {
+    dispatch({ type: ActionTypes.CreateRecapSuccess, payload: createdRecap });
+  };
+  const onUpdateRecapSuccess = (updatedRecap: Recap) => {
+    dispatch({ type: ActionTypes.UpdateRecapSuccess, payload: updatedRecap });
+  };
+  const onDeleteRecapSuccess = (deletedRecap: Recap) => {
+    dispatch({ type: ActionTypes.DeleteRecapSuccess, payload: deletedRecap });
+  };
+
   if (isFetchingRecaps) {
     return (
       <div data-testid="recapsPageLoading" className={cn("p-6", "h-screen", "flex", "flex-col")}>
@@ -321,9 +608,9 @@ const RecapsPage = () => {
         <WorkExperienceLayout
           recaps={recapsMap.workExperience}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -331,9 +618,9 @@ const RecapsPage = () => {
         <EducationLayout
           recaps={recapsMap.education}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -341,9 +628,9 @@ const RecapsPage = () => {
         <AccomplishmentsLayout
           recaps={recapsMap.accomplishments}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -351,9 +638,9 @@ const RecapsPage = () => {
         <OrganizationsLayout
           recaps={recapsMap.organizations}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -361,9 +648,9 @@ const RecapsPage = () => {
         <SkillsLayout
           recaps={recapsMap.skills}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -371,9 +658,9 @@ const RecapsPage = () => {
         <SideProjectsLayout
           recaps={recapsMap.sideProjects}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -381,9 +668,9 @@ const RecapsPage = () => {
         <PublicationsLayout
           recaps={recapsMap.publications}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -391,9 +678,9 @@ const RecapsPage = () => {
         <ReferencesLayout
           recaps={recapsMap.references}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
 
@@ -401,9 +688,9 @@ const RecapsPage = () => {
         <OtherLayout
           recaps={recapsMap.other}
           onGoBackToLanding={onGoBackToLanding}
-          onCreateRecapSuccess={() => {}}
-          onUpdateRecapSuccess={() => {}}
-          onDeleteRecapSuccess={() => {}}
+          onCreateRecapSuccess={onCreateRecapSuccess}
+          onUpdateRecapSuccess={onUpdateRecapSuccess}
+          onDeleteRecapSuccess={onDeleteRecapSuccess}
         />
       )}
     </div>

--- a/packages/frontend/src/pages/Recaps/index.tsx
+++ b/packages/frontend/src/pages/Recaps/index.tsx
@@ -220,7 +220,7 @@ const recapsAdapter = (recaps: Recap[]): RecapsMap => {
     other,
   };
 
-  console.log(recapsMap);
+  // console.log(recapsMap);
 
   return recapsMap;
 };
@@ -541,8 +541,7 @@ const RecapsPage = () => {
       type: ActionTypes.GetRecapsRequest,
     });
     getRecaps()
-      .then(response => {
-        const recaps = response.data;
+      .then(recaps => {
         dispatch({
           type: ActionTypes.GetRecapsSuccess,
           payload: recaps,

--- a/packages/frontend/src/pages/Recaps/recaps.service.ts
+++ b/packages/frontend/src/pages/Recaps/recaps.service.ts
@@ -1,18 +1,38 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { Recap } from "./recaps.interface";
 
-export const getRecaps = () => {
-  return axios.get<Recap[]>("/recaps");
+export const getRecaps = (): Promise<Recap[]> => {
+  return axios
+    .get<Recap[]>("/recaps")
+    .then(response => response.data)
+    .catch((error: AxiosError) => {
+      throw new Error(`${error.code} error: ${error.message}`);
+    });
 };
 
-export const createRecap = (recapToCreate: Omit<Recap, "_id">) => {
-  return axios.post<Recap>("/recaps", recapToCreate);
+export const createRecap = (recapToCreate: Omit<Recap, "_id">): Promise<Recap> => {
+  return axios
+    .post<Recap>("/recaps", recapToCreate)
+    .then(response => response.data)
+    .catch((error: AxiosError) => {
+      throw new Error(`${error.code} error: ${error.message}`);
+    });
 };
 
-export const updateRecap = (updatedRecap: Recap) => {
-  return axios.patch<Recap>(`/recaps/${updatedRecap._id}`, updatedRecap);
+export const updateRecap = (updatedRecap: Recap): Promise<Recap> => {
+  return axios
+    .patch<Recap>(`/recaps/${updatedRecap._id}`, updatedRecap)
+    .then(response => response.data)
+    .catch((error: AxiosError) => {
+      throw new Error(`${error.code} error: ${error.message}`);
+    });
 };
 
-export const deleteRecap = (recapId: Recap["_id"]) => {
-  return axios.delete<Recap>(`/recaps/${recapId}`);
+export const deleteRecap = (recapId: Recap["_id"]): Promise<Recap> => {
+  return axios
+    .delete<Recap>(`/recaps/${recapId}`)
+    .then(response => response.data)
+    .catch((error: AxiosError) => {
+      throw new Error(`${error.code} error: ${error.message}`);
+    });
 };


### PR DESCRIPTION
Resolves #114 in creating useDeleteRecap, useRecapAlerts hooks, Alert success/error components, integrated delete flow into all recaps kind layouts
Normalized axios requests in recaps service so we can mock them out easier in unit/integration tests for the layouts